### PR TITLE
Diazo theme is not applied when rendering 404 error page

### DIFF
--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -184,9 +184,8 @@ def createExpressionContext(context, request):
     expressions.
     """
 
-    portal = getPortal()
     if not context:
-        context = portal
+        context = getPortal()
 
     contextState = queryMultiAdapter(
         (context, request), name=u"plone_context_state")


### PR DESCRIPTION
createExpressionContext method assumes context exists.

But that is not always the case (typical example: we call an non-existant url like http://server/portal/bad-id, so we are supposed to see the default error page, but obviously the context cannot be extracted from the current request).

To solve that, the proposed patch use portal as context when context is none.
