### PR TITLE
Comment the href attribute example rule to emphasise how arbitrary content can be sourced from a browser view

### DIFF
--- a/src/plone/app/theming/browser/resources/userguide.rst
+++ b/src/plone/app/theming/browser/resources/userguide.rst
@@ -692,6 +692,7 @@ Rules may operate on content that is fetched from somewhere other than the
 current page being rendered by Plone, by using the ``href`` attribute to specify
 a path of a resource relative to the root of the Plone site::
 
+    <!-- Pull in extra navigation from a browser view on the Plone site root -->
     <after
         css:theme-children="#leftnav"
         css:content=".navitem"


### PR DESCRIPTION
Laurence mentioned in a [mailing list thread](http://plone.293351.n2.nabble.com/Simplifying-the-schema-story-tp7558876p7558981.html) that an href attribute on rules lets you "include elements from subrequests into your final page (no need to write viewlets, just write a utility view for your theme)". Such a handy technique deserves emphasis in the `plone.app.theming` user guide.

Added a comment to the href attribute example rule to make clearer that content can be sourced from a browser view.
