### PR TITLE
Ensure hostname blacklisting correctly determines incoming hostname

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.1b2 (unreleased)
 ------------------
 
+- Ensure host blacklist utilises SERVER_URL to correctly determine hostname
+  for sites hosted as sub-folders at any depth.
+  [davidjb]
+
 - Add test about plone.app.theming / plone.app.caching integration when
   using GZIP compression for anonymous
   (see ticket `12038 <https://dev.plone.org/ticket/12038>`_). [ebrehault]

--- a/src/plone/app/theming/tests/test_utils.py
+++ b/src/plone/app/theming/tests/test_utils.py
@@ -108,6 +108,44 @@ class TestIntegration(unittest.TestCase):
         self.assertEqual(settings.absolutePrefix, None)
         self.assertEqual(settings.parameterExpressions, {})
 
+    def test_isThemeEnabled(self):
+        from zope.component import getUtility
+
+        from plone.registry.interfaces import IRegistry
+
+        from plone.app.theming.interfaces import IThemeSettings
+        from plone.app.theming.utils import isThemeEnabled
+
+        settings = getUtility(IRegistry).forInterface(IThemeSettings, False)
+        settings.enabled = True
+        settings.rules = u"/++theme++foo/rules.xml"
+
+        request = self.layer['request']
+
+        self.assertTrue(isThemeEnabled(request, settings))
+
+    def test_isThemeEnabled_blacklist(self):
+        from zope.component import getUtility
+
+        from plone.registry.interfaces import IRegistry
+
+        from plone.app.theming.interfaces import IThemeSettings
+        from plone.app.theming.utils import isThemeEnabled
+
+        settings = getUtility(IRegistry).forInterface(IThemeSettings, False)
+        settings.enabled = True
+        settings.rules = u"/++theme++foo/rules.xml"
+
+        request = self.layer['request']
+        request.set('BASE1', 'http://nohost/path/to/site')
+
+        self.assertTrue(isThemeEnabled(request, settings))
+        self.assertEqual(request.get('SERVER_URL'), 'http://nohost')
+
+        #Should pay no attention to BASE1 and only use SERVER_URL
+        settings.hostnameBlacklist.append('nohost')
+        self.assertFalse(isThemeEnabled(request, settings))
+
 
 class TestUnit(unittest.TestCase):
 

--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -423,9 +423,9 @@ def isThemeEnabled(request, settings=None):
     if not settings.enabled or not settings.rules:
         return False
 
-    base1 = request.get('BASE1')
-    _, base1 = base1.split('://', 1)
-    host = base1.lower()
+    server_url = request.get('SERVER_URL')
+    _, host = server_url.split('://', 1)
+    host = host.lower()
     serverPort = request.get('SERVER_PORT')
 
     for hostname in settings.hostnameBlacklist or ():


### PR DESCRIPTION
At present, plone.app.theming relies on BASE1 from the request object in order to attempt to ascertain the hostname of the request. These BASEx variables encompass the path to a Plone site/Zope install -- and are problematic when a site is hosted on a sub-directory (or sub-sub-directory, etc).  Since BASE1 contains a path, this isn't necessarily going to be just the server URL.

Looking at the ZPublisher, SERVER_URL is built up from the relevant CGI-style environment variables and should be value used.
