### PR TITLE
Fix reference to theme error template

### DIFF
--- a/src/plone/app/theming/browser/mapper.py
+++ b/src/plone/app/theming/browser/mapper.py
@@ -229,7 +229,7 @@ class ThemeMapper(BrowserView):
             try:
                 transform = compileThemeTransform(themeInfo.rules, themeInfo.absolutePrefix, settings.readNetwork, themeInfo.parameterExpressions or {})
             except lxml.etree.XMLSyntaxError, e:
-                return self.themeInfo_error_template(error=e.msg)
+                return self.theme_error_template(error=e.msg)
 
             params = prepareThemeParameters(context, self.request, themeInfo.parameterExpressions or {})
 


### PR DESCRIPTION
This returns the object returned in case of an error in the rules file to the expression that was used before 0ba898cd2, as the change made to this in that commit was clearly an mistake during the rename of the "theme" variable to "themeInfo".
