### PR TITLE
++theme++current

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -6,11 +6,15 @@ Changelog
 
 - Put themes in a separate zcml file to be able to exclude them
   [laulaz]
-  
-- #14107 bot requests like /widget/oauth_login/info.txt causes 
+
+- #14107 bot requests like /widget/oauth_login/info.txt causes
   problems finding correct context with plone.app.theming
   [anthonygerrard]
 
+- Added support for ++theme++ to traverse to the contents of the
+  current activated theme.
+  [bosim]
+  
 
 1.2.0 (2014-03-02)
 ------------------

--- a/src/plone/app/theming/traversal.py
+++ b/src/plone/app/theming/traversal.py
@@ -30,7 +30,7 @@ class ThemeTraverser(ResourceTraverser):
     def traverse(self, name, remaining):
         type = self.name
 
-        if name == 'current':
+        if name == '':
             name = self.current_theme()
 
         # Note: also fixes possible unicode problems


### PR DESCRIPTION
Sometimes it is need to do relative lookups of the static contents in the theme e.g. from the tinymce controlpanel for the specific style file. This fix adds ++theme++current that will always point to the activated theme.
