### PR TITLE
fix AttributeError: 'NoneType' object has no attribute 'getroottree' whe...

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- fix AttributeError: 'NoneType' object has no attribute 'getroottree' when the result is not
+  html / is empty.
+  [sunew]
 
 
 1.2.1 (2014-10-23)

--- a/src/plone/app/theming/transform.py
+++ b/src/plone/app/theming/transform.py
@@ -137,7 +137,7 @@ class ThemeTransform(object):
 
         try:
             return getHTMLSerializer(result, pretty_print=False)
-        except (TypeError, etree.ParseError):
+        except (AttributeError, TypeError, etree.ParseError):
             return None
 
     def transformString(self, result, encoding):


### PR DESCRIPTION
...n the result is not html / is empty.

Triggered by an ajax request.