### PR TITLE
Fix issue where skinsSettings does not have use_popups attribute on Plone 5

### DIFF
--- a/src/plone/app/theming/browser/controlpanel.pt
+++ b/src/plone/app/theming/browser/controlpanel.pt
@@ -530,7 +530,8 @@
 
                     <div
                         class="field"
-                        tal:define="selected python:request.get('usePopups', view.skinsSettings.use_popups)">
+                        tal:define="selected_default view/skinsSettings/use_popups|python:False;
+                                    selected python:request.get('usePopups', selected_default)">
 
                         <input type="hidden" value="" name="usePopups:boolean:default" />
                         <input type="checkbox" value="1" name="usePopups:boolean" id="usePopups"


### PR DESCRIPTION
I'm not sure about all things going on for Plone 5, but this was required for me to get theming control panel open on Plone 5 (master).
