### PR TITLE
Fix transform to not affect the result when theming is disabled

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,9 @@ Changelog
 1.3.0 (unreleased)
 ------------------
 
+- Fix transform to not affect the result when theming is disabled
+  [datakurre]
+
 - Integrate thememapper mockup pattern and fix theming control panel
   to be more usable
   [ebrehault]

--- a/src/plone/app/theming/transform.py
+++ b/src/plone/app/theming/transform.py
@@ -149,6 +149,14 @@ class ThemeTransform(object):
     def transformIterable(self, result, encoding):
         """Apply the transform if required
         """
+        # Obtain settings. Do nothing if not found
+        settings = self.getSettings()
+
+        if settings is None:
+            return None
+
+        if not isThemeEnabled(self.request, settings):
+            return None
 
         result = self.parseTree(result)
         if result is None:
@@ -161,7 +169,6 @@ class ThemeTransform(object):
         try:
             etree.clear_error_log()
 
-            settings = self.getSettings()
             if settings.doctype:
                 result.doctype = settings.doctype
                 if not result.doctype.endswith('\n'):


### PR DESCRIPTION
IMHO. Theming transform should not have any side effects, when theming is disabled. The current implementation may change result doctype and does call getHTMLSerializer, which may change the result.serializer. Both even when theming is disabled in settings.

/cc https://github.com/plone/plone.app.blocks/issues/15