### PR TITLE
Fix on support for IThemePlugin.onEnabled

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.1.5 (unreleased)
 ------------------
 
+- Fix load pluginSettings for the enabled theme before calling plugins for
+  onEnabled and call onEnabled plugins with correct parameters
+  [datakurre]
+
 - Add an error log if the subrequest failed (probably a relative xi:include)
   instead of silently returning None (and so having a xi:include returning
   nothing).

--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -499,6 +499,15 @@ def applyTheme(theme):
             for name, plugin in plugins:
                 plugin.onDisabled(currentTheme, pluginSettings[name],
                                   pluginSettings)
+
+        themeDirectory = queryResourceDirectory(
+            THEME_RESOURCE_NAME, settings.currentTheme)
+        if themeDirectory is not None:
+            plugins = getPlugins()
+            pluginSettings = getPluginSettings(themeDirectory, plugins)
+
+        if pluginSettings is not None:
+            for name, plugin in plugins:
                 plugin.onEnabled(theme, pluginSettings[name], pluginSettings)
 
 

--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -167,7 +167,7 @@ def findContext(request):
     context = getattr(published, '__parent__', None)
     if context is not None:
         return context
-    
+
     for parent in request.PARENTS:
         if IContentish.providedBy(parent) or ISiteRoot.providedBy(parent):
             return parent
@@ -500,15 +500,17 @@ def applyTheme(theme):
                 plugin.onDisabled(currentTheme, pluginSettings[name],
                                   pluginSettings)
 
+        currentTheme = settings.currentTheme
         themeDirectory = queryResourceDirectory(
-            THEME_RESOURCE_NAME, settings.currentTheme)
+            THEME_RESOURCE_NAME, currentTheme)
         if themeDirectory is not None:
             plugins = getPlugins()
             pluginSettings = getPluginSettings(themeDirectory, plugins)
 
         if pluginSettings is not None:
             for name, plugin in plugins:
-                plugin.onEnabled(theme, pluginSettings[name], pluginSettings)
+                plugin.onEnabled(currentTheme, pluginSettings[name],
+                                 pluginSettings)
 
 
 def createThemeFromTemplate(title, description, baseOn='template'):


### PR DESCRIPTION
This seem to be quite the same as #28 for 1.1.x branch, but properly passes theme name instead of theme object.