### PR TITLE
 Fix on support for IThemePlugin.onEnabled

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -5,7 +5,7 @@ Changelog
 ------------------
 
 - Fix load pluginSettings for the enabled theme before calling plugins for
-  onEnabled
+  onEnabled and call onEnabled plugins with correct parameters
   [datakurre]
 
 

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,7 +4,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix load pluginSettings for the enabled theme before calling plugins for
+  onEnabled
+  [datakurre]
 
 
 1.2.1 (2014-10-23)

--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -515,6 +515,15 @@ def applyTheme(theme):
             for name, plugin in plugins:
                 plugin.onDisabled(currentTheme, pluginSettings[name],
                                   pluginSettings)
+
+        themeDirectory = queryResourceDirectory(
+            THEME_RESOURCE_NAME, settings.currentTheme)
+        if themeDirectory is not None:
+            plugins = getPlugins()
+            pluginSettings = getPluginSettings(themeDirectory, plugins)
+
+        if pluginSettings is not None:
+            for name, plugin in plugins:
                 plugin.onEnabled(theme, pluginSettings[name], pluginSettings)
         notify(ThemeAppliedEvent(theme))
 

--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -516,15 +516,17 @@ def applyTheme(theme):
                 plugin.onDisabled(currentTheme, pluginSettings[name],
                                   pluginSettings)
 
+        currentTheme = settings.currentTheme
         themeDirectory = queryResourceDirectory(
-            THEME_RESOURCE_NAME, settings.currentTheme)
+            THEME_RESOURCE_NAME, currentTheme)
         if themeDirectory is not None:
             plugins = getPlugins()
             pluginSettings = getPluginSettings(themeDirectory, plugins)
 
         if pluginSettings is not None:
             for name, plugin in plugins:
-                plugin.onEnabled(theme, pluginSettings[name], pluginSettings)
+                plugin.onEnabled(currentTheme, pluginSettings[name],
+                                 pluginSettings)
         notify(ThemeAppliedEvent(theme))
 
 


### PR DESCRIPTION
This seem to be quite the same as #28 for 1.2.x branch, but properly passes theme name instead of theme object.