### PR TITLE
 Fix on support for IThemePlugin.onEnabled

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -10,6 +10,10 @@ Changelog
 - pat-modal pattern has been renamed to pat-plone-modal
   [jcbrand]
 
+- Fix load pluginSettings for the enabled theme before calling plugins for
+  onEnabled
+  [datakurre]
+
 
 1.2.2 (2015-03-22)
 ------------------

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -11,7 +11,7 @@ Changelog
   [jcbrand]
 
 - Fix load pluginSettings for the enabled theme before calling plugins for
-  onEnabled
+  onEnabled and call onEnabled plugins with correct parameters
   [datakurre]
 
 

--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -564,15 +564,17 @@ def applyTheme(theme):
                 plugin.onDisabled(currentTheme, pluginSettings[name],
                                   pluginSettings)
 
+        currentTheme = settings.currentTheme
         themeDirectory = queryResourceDirectory(
-            THEME_RESOURCE_NAME, settings.currentTheme)
+            THEME_RESOURCE_NAME, currentTheme)
         if themeDirectory is not None:
             plugins = getPlugins()
             pluginSettings = getPluginSettings(themeDirectory, plugins)
 
         if pluginSettings is not None:
             for name, plugin in plugins:
-                plugin.onEnabled(theme, pluginSettings[name], pluginSettings)
+                plugin.onEnabled(currentTheme, pluginSettings[name],
+                                 pluginSettings)
         notify(ThemeAppliedEvent(theme))
 
 

--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -563,6 +563,15 @@ def applyTheme(theme):
             for name, plugin in plugins:
                 plugin.onDisabled(currentTheme, pluginSettings[name],
                                   pluginSettings)
+
+        themeDirectory = queryResourceDirectory(
+            THEME_RESOURCE_NAME, settings.currentTheme)
+        if themeDirectory is not None:
+            plugins = getPlugins()
+            pluginSettings = getPluginSettings(themeDirectory, plugins)
+
+        if pluginSettings is not None:
+            for name, plugin in plugins:
                 plugin.onEnabled(theme, pluginSettings[name], pluginSettings)
         notify(ThemeAppliedEvent(theme))
 


### PR DESCRIPTION
This seem to be quite the same as #28, but properly passes theme name instead of theme object.

Just didn't look into existing pulls before figuring out otherwise identical fix.