### PR TITLE
thememapper now has an 'inspector' mode for filesystem themes

### DIFF
--- a/src/plone/app/theming/browser/mapper.pt
+++ b/src/plone/app/theming/browser/mapper.pt
@@ -75,6 +75,13 @@
             reflected on the live site.
         </span>
       </div>
+      <div class="portalMessage warning"
+        tal:condition="not: view/editable">
+        <strong i18n:translate="">Warning</strong>
+        <span tal:omit-tag="" i18n:translate="theming_mapper_warning_live">
+			This is a built-in theme, and cannot be edited.
+        </span>
+      </div>
     </aside>
 
 
@@ -98,9 +105,8 @@
 
           <section id="content-core">
             <input tal:replace="structure context/@@authenticator/authenticator" />
-            <div class="pat-thememapper"
-				data-pat-thememapper='
-					  themeUrl: ${view/resourceUrl};
+            <div class="pat-thememapper" data-pat-thememapper='themeUrl: ${view/resourceUrl};
+					  editable: ${view/editable};
                       filemanagerConfig:{"actionUrl":"${view/themeBaseUrl}/@@plone.resourceeditor.filemanager-actions"};
                       mockupUrl:${view/themeBaseUrl}/@@theming-controlpanel-mapper-getframe?path=/${view/themeBasePathEncoded}/${view/defaultThemeFile}&amp;theme=off;
                       unthemedUrl:${view/themeBaseUrl}/@@theming-controlpanel-mapper-getframe?path=/&amp;diazo.off=1;

--- a/src/plone/app/theming/browser/mapper.py
+++ b/src/plone/app/theming/browser/mapper.py
@@ -74,11 +74,15 @@ class ThemeMapper(BrowserView):
         )
         self.themeBasePathEncoded = urllib.quote_plus(self.themeBasePath)
         self.themeBaseUrl = '/'.join([self.portalUrl, self.themeBasePath])
-        self.resourceUrl = self.resourceDirectory.context.absolute_url()        
-
+            
         self.editable = IWritableResourceDirectory.providedBy(
             self.resourceDirectory
         )
+
+        if self.editable:
+            self.resourceUrl = self.resourceDirectory.context.absolute_url() 
+        else:
+            self.resourceUrl = None
 
         settings = getUtility(IRegistry).forInterface(IThemeSettings, False)
         self.active = (settings.enabled and self.name == getCurrentTheme())


### PR DESCRIPTION
The thememapper will now open in inspector mode when viewing a filesystem theme