### PR TITLE
Fix for copied theme configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.2.7 (unreleased)
 ------------------
 
+- fixed configuration of copied theme
+  [vmaksymiv]
+
 - implemented upload for theme manager
   [schwartz]
 

--- a/src/plone/app/theming/tests/configure.zcml
+++ b/src/plone/app/theming/tests/configure.zcml
@@ -6,6 +6,7 @@
     <include package="plone.app.theming"/>
 
     <plone:static directory="resources" type="theme" />
+    <plone:static directory="secondary-theme" name="secondary-theme" type="theme" />
 
     <browser:page
         for="*"

--- a/src/plone/app/theming/tests/secondary-theme/manifest.cfg
+++ b/src/plone/app/theming/tests/secondary-theme/manifest.cfg
@@ -1,0 +1,6 @@
+[theme]
+title = Secondary test theme
+description = Secondary theme for testing
+doctype = <!DOCTYPE html>
+prefix = /++theme++secondary-test-theme
+rules = /++theme++secondary-test-theme/rules.xml

--- a/src/plone/app/theming/tests/secondary-theme/rules.xml
+++ b/src/plone/app/theming/tests/secondary-theme/rules.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules
+    xmlns="http://namespaces.plone.org/diazo"
+    xmlns:css="http://namespaces.plone.org/diazo/css"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+</rules>

--- a/src/plone/app/theming/tests/test_utils.py
+++ b/src/plone/app/theming/tests/test_utils.py
@@ -167,6 +167,52 @@ class TestIntegration(unittest.TestCase):
         settings.hostnameBlacklist.append('nohost')
         self.assertFalse(isThemeEnabled(request, settings))
 
+    def test_createThemeFromTemplate(self):
+        from plone.app.theming.utils import createThemeFromTemplate
+        from plone.app.theming.utils import getAvailableThemes
+        from plone.app.theming.utils import getTheme
+        from plone.app.theming.interfaces import THEME_RESOURCE_NAME
+        from plone.app.theming.interfaces import RULE_FILENAME
+        title = "copy of test theme"
+        description = "test theme creation"
+        themeName = createThemeFromTemplate(title, description,
+                                            baseOn="plone.app.theming.tests")
+        titles = [theme.title for theme in getAvailableThemes()]
+        self.assertTrue(title in titles)
+
+        theme = getTheme(themeName)
+        expected_prefix = u"/++%s++%s" % (THEME_RESOURCE_NAME,
+                                          title.replace(" ", "-"))
+        self.assertEqual(theme.absolutePrefix, expected_prefix)
+
+        expected_rules = u"/++%s++%s/%s" % (THEME_RESOURCE_NAME,
+                                            title.replace(" ", "-"),
+                                            RULE_FILENAME)
+        self.assertEqual(theme.rules, expected_rules)
+
+    def test_createThemeFromTemplate_custom_prefix(self):
+        from plone.app.theming.utils import createThemeFromTemplate
+        from plone.app.theming.utils import getAvailableThemes
+        from plone.app.theming.utils import getTheme
+        from plone.app.theming.interfaces import THEME_RESOURCE_NAME
+        from plone.app.theming.interfaces import RULE_FILENAME
+        title = "copy of test theme with custom prefix"
+        description = "test theme creation"
+        themeName = createThemeFromTemplate(title, description,
+                                            baseOn="secondary-theme")
+        titles = [theme.title for theme in getAvailableThemes()]
+        self.assertTrue(title in titles)
+
+        theme = getTheme(themeName)
+        expected_prefix = u"/++%s++%s" % (THEME_RESOURCE_NAME,
+                                          title.replace(" ", "-"))
+        self.assertEqual(theme.absolutePrefix, expected_prefix)
+
+        expected_rules = u"/++%s++%s/%s" % (THEME_RESOURCE_NAME,
+                                            title.replace(" ", "-"),
+                                            RULE_FILENAME)
+        self.assertEqual(theme.rules, expected_rules)
+
 
 class TestUnit(unittest.TestCase):
 

--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -548,6 +548,17 @@ def createThemeFromTemplate(title, description, baseOn='template'):
     manifest.set('theme', 'title', title)
     manifest.set('theme', 'description', description)
 
+    if manifest.has_option('theme', 'prefix'):
+        prefix = u"/++%s++%s" % (THEME_RESOURCE_NAME, themeName)
+        manifest.set('theme', 'prefix', prefix)
+
+    if manifest.has_option('theme', 'rules'):
+        rule = manifest.get('theme', 'rules')
+        rule_file_name = rule.split('/')[-1]  # extract real rules file name
+        rules = u"/++%s++%s/%s" % (THEME_RESOURCE_NAME, themeName,
+                                   rule_file_name)
+        manifest.set('theme', 'rules', rules)
+
     manifestContents = StringIO()
     manifest.write(manifestContents)
     target.writeFile(MANIFEST_FILENAME, manifestContents)


### PR DESCRIPTION
While a theme contains custom 'prefix' and/or 'rules' configuration it is impossible to copy and activate copied theme. The following changes fix the problem.