### PR TITLE
improve test isolation

### DIFF
--- a/src/plone/app/theming/tests/test_policy.py
+++ b/src/plone/app/theming/tests/test_policy.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import time
-import multiprocessing
 import threading
 import transaction
 import unittest2 as unittest
@@ -16,10 +15,16 @@ class TestFunctional(unittest.TestCase):
 
     layer = THEMING_FUNCTIONAL_TESTING
 
+    def setUp(self):
+        request = self.layer['request']
+        policy = theming_policy(request)
+        # avoid cache pollution from other tests
+        policy.invalidateCache()
+
     def tearDown(self):
         request = self.layer['request']
         policy = theming_policy(request)
-        # static class attribute is cached across test runs
+        # clear local thread caches
         policy.invalidateCache()
 
     def test_getSettings(self):


### PR DESCRIPTION
While testing CMFPlone PR https://github.com/plone/Products.CMFPlone/pull/667 the Jenkins results indicate test failures because of theme caches leaking in.
http://jenkins.plone.org/job/pull-request-5.0/57/console

While I cannot reproduce that test failure locally, this PR improves test isolation to cut off any theme caches leaking in from other tests.