### PR TITLE
Added cache invalidation option

### DIFF
--- a/src/plone/app/theming/browser/controlpanel.pt
+++ b/src/plone/app/theming/browser/controlpanel.pt
@@ -169,6 +169,12 @@
                                     class="plone-btn plone-btn-default"
                                     type="submit"
                                     name="form.button.Disable">Deactivate</button>
+                                <button
+                                    tal:condition="theme/selected"
+                                    i18n:translate=""
+                                    class="plone-btn plone-btn-default"
+                                    type="submit"
+                                    name="form.button.InvalidateCache">Clear Cache</button>
                             </form>
 
                             <a href="#" class="plone-btn plone-btn-default pat-plone-modal"

--- a/src/plone/app/theming/browser/controlpanel.py
+++ b/src/plone/app/theming/browser/controlpanel.py
@@ -11,6 +11,7 @@ from plone.app.theming.interfaces import THEME_RESOURCE_NAME
 from plone.app.theming.interfaces import _
 from plone.app.theming.plugins.utils import getPluginSettings
 from plone.app.theming.plugins.utils import getPlugins
+from plone.app.theming.utils import theming_policy
 from plone.app.theming.utils import applyTheme
 from plone.app.theming.utils import createThemeFromTemplate
 from plone.app.theming.utils import extractThemeInfo
@@ -145,6 +146,12 @@ class ThemingControlpanel(BrowserView):
                 )
             )
             self._setup()
+            return True
+
+        if 'form.button.InvalidateCache' in form:
+            self.authorize()
+            policy = theming_policy()
+            policy.invalidateCache()
             return True
 
         if 'form.button.Disable' in form:


### PR DESCRIPTION
Added option to allow thememapper users to invalidate the site-wide theme cache, forcing a reload.