### PR TITLE
Fix AttributeErrors if current context is not within a plonesite

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix AttributeErrors on parameter evaluation if current context is not
+  located within a plonesite [fRiSi]
 
 
 1.0.4 (2012-12-14)

--- a/src/plone/app/theming/transform.py
+++ b/src/plone/app/theming/transform.py
@@ -254,7 +254,10 @@ class ThemeTransform(object):
             context = findContext(self.request)
             expressionContext = createExpressionContext(context, self.request)
             for name, expression in expressions.items():
-                params[name] = quote_param(expression(expressionContext))
+                try:
+                    params[name] = quote_param(expression(expressionContext))
+                except AttributeError:
+                    pass
 
         transformed = transform(result.tree, **params)
         if transformed is None:

--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -90,7 +90,10 @@ class InternalResolver(etree.Resolver):
         if portalState is None:
             root = None
         else:
-            root = portalState.navigation_root()
+            try:
+                root = portalState.navigation_root()
+            except AttributeError:
+                root = None
 
         if not system_url.startswith('/'):  # only for relative urls
             root_path = root.getPhysicalPath()
@@ -140,7 +143,10 @@ def getPortal():
         (context, request), name=u"plone_portal_state")
     if portalState is None:
         return None
-    return portalState.portal()
+    try:
+        return portalState.portal()
+    except AttributeError:
+        return None
 
 
 def findContext(request):
@@ -189,10 +195,15 @@ def createExpressionContext(context, request):
     portalState = queryMultiAdapter(
         (context, request), name=u"plone_portal_state")
 
+    try:
+        portal = portalState.portal()
+    except AttributeError:
+        portal = None
+
     data = {
         'context': context,
         'request': request,
-        'portal': portalState.portal(),
+        'portal': portal,
         'context_state': contextState,
         'portal_state': portalState,
         'nothing': None,


### PR DESCRIPTION
i stumbled upon this when accessing a resource outside of a plone site through acquisition.

ie following site structure:
```
/folder1/Plone
/folder2/Plone
```

accessing http://localhost:8080/folder1/Plone/folder2
leads to AttributeErrors

this pr would fix this issue. (alternatively [collective.siteisolation](https://github.com/collective/collective.siteisolation) might also solve the problem)

if you thinks this pr is reasonable, i'll provide pull requests for 1.1.x and 1.2.x releases as well

