### PR TITLE
Backport Diazo rules caching in development mode, backwards compatible

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.1.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Control theme compilation in development mode
+  through the environment variable ``DIAZO_ALWAYS_CACHE_RULES``
+  [ale-rt]
 
 
 1.1.7 (2015-07-14)

--- a/src/plone/app/theming/tests/test_transform.py
+++ b/src/plone/app/theming/tests/test_transform.py
@@ -1,6 +1,8 @@
+from os import environ
 import unittest2 as unittest
 
 from plone.app.theming.testing import THEMING_FUNCTIONAL_TESTING
+
 from plone.testing.z2 import Browser
 
 from plone.app.testing import setRoles, TEST_USER_ID
@@ -18,6 +20,7 @@ from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
 
 from plone.app.theming.interfaces import IThemeSettings
+from plone.app.theming.transform import ThemeTransform
 from plone.app.theming.utils import applyTheme, getAvailableThemes, getTheme
 from plone.app.theming.utils import InternalResolver, PythonResolver, resolvePythonURL
 
@@ -91,6 +94,30 @@ class TestCase(unittest.TestCase):
 
         # The theme
         self.assertTrue("This is the theme" in browser.contents)
+
+    def test_develop_theme(self):
+        ''' Check if the rules are developed
+        '''
+        # First we check the status of our environment variables
+        var_name = 'DIAZO_ALWAYS_CACHE_RULES'
+        env_had_var = var_name in environ
+        # and clean it up
+        env_var_backup = environ.pop(var_name, None)
+
+        transform = ThemeTransform(None, None)
+        # This evaluates to True because we set
+        # Globals.DevelopmentMode to True in the test setup
+        self.assertTrue(transform.develop_theme())
+
+        # But we can anyway force the cache
+        environ[var_name] = 'true'
+        self.assertFalse(transform.develop_theme())
+
+        # Then we reset our env variables before leaving
+        if env_had_var:
+            environ[var_name] = env_var_backup
+        else:
+            del environ[var_name]
 
     def test_theme_enabled_resource_directory(self):
 

--- a/src/plone/app/theming/transform.py
+++ b/src/plone/app/theming/transform.py
@@ -1,5 +1,6 @@
 import logging
 import Globals
+from os import environ
 
 from lxml import etree
 
@@ -21,6 +22,7 @@ from plone.app.theming.utils import isThemeEnabled
 from plone.app.theming.utils import findContext
 from plone.app.theming.utils import getParser
 from plone.app.theming.zmi import patch_zmi
+
 
 # Disable theming of ZMI
 patch_zmi()
@@ -78,9 +80,20 @@ class ThemeTransform(object):
         self.published = published
         self.request = request
 
+    def develop_theme(self):
+        ''' Check if the theme should be recompiled every time the
+        transform is applied
+        '''
+        if Globals.DevelopmentMode:
+            if environ.get('DIAZO_ALWAYS_CACHE_RULES'):
+                return False
+            else:
+                return True
+        return False
+
     def setupTransform(self, runtrace=False):
         request = self.request
-        DevelopmentMode = Globals.DevelopmentMode
+        DevelopmentMode = self.develop_theme()
 
         # Obtain settings. Do nothing if not found
         settings = self.getSettings()


### PR DESCRIPTION
This is a backport of https://github.com/plone/plone.app.theming/commit/8dc465352c925fd21cd967d7be852ecc3cfeb126 from @ale-rt for plone.app.theming 1.1.X and makes this available in Plone 4.

cherry-picked, ran the package tests and verified with a simple load test on my local machine that enabling this on the stock Diazo test theme provided in Plone 4's plone.app.theming this gives consistent 25% increase of requests per second for that theme, so caching gets enabled. 