### PR TITLE
Fix issue where global resource directory overrides broke control panel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,10 @@ Fixes:
 - Small fix in documentation
   [staeff]
 
+- Fix issue where theming control panel errored when a packaged
+  theme was overidden with a global resource directory theme
+  [datakurre]
+
 1.3.0 (2016-06-07)
 ------------------
 

--- a/src/plone/app/theming/browser/controlpanel.py
+++ b/src/plone/app/theming/browser/controlpanel.py
@@ -433,8 +433,12 @@ class ThemingControlpanel(BrowserView):
             # Is there more than one theme with the same name?
             if len(filter(lambda x: x.__name__ == theme.__name__, self.availableThemes)) > 1:
                 # Then we make sure we're using the TTW version, not the filesystem version.
-                theme = filter(lambda x: x.__name__ == theme.__name__, self.zodbThemes)[0]
-                override = True
+                try:
+                    theme = filter(lambda x: x.__name__ == theme.__name__, self.zodbThemes)[0]
+                    override = True
+                # Or when TTW is not available, the first available filesystem version.
+                except IndexError:
+                    theme = filter(lambda x: x.__name__ == theme.__name__, self.availableThemes)[0]
 
             previewUrl = "++resource++plone.app.theming/defaultPreview.png"
             if theme.preview:


### PR DESCRIPTION
plone.resource supports three different resource locations 1) ZODB, 2) global resource directory 3) packages and iterates the options in that order.

Currently, the theming control panel supports situation where ZODB theme overrides packaged theme, but crashes when global resource directory theme overrides packaged theme. This pull fixes that and allows overriding packaged themes with a global filesystem resource directory override. (It was possible already, but only controlpanel being broken.)

I did not add override "warning" for that, because you probably know, when you are doing that. Overriding theme with ZODB version still gives the warning.
