### PR TITLE
Add update button to theming control panel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Add Update -button for theming control panel making it possible to
+  reload modified theme manifest without deactivating theme at first.
+  [datakurre]
 
 Fixes:
 

--- a/src/plone/app/theming/browser/controlpanel.pt
+++ b/src/plone/app/theming/browser/controlpanel.pt
@@ -166,6 +166,12 @@
                                     i18n:translate=""
                                     class="plone-btn plone-btn-default"
                                     type="submit"
+                                    name="form.button.Enable">Update</button>
+                                <button
+                                    tal:condition="theme/selected"
+                                    i18n:translate=""
+                                    class="plone-btn plone-btn-default"
+                                    type="submit"
                                     name="form.button.Disable">Deactivate</button>
                                 <button
                                     tal:condition="theme/selected"


### PR DESCRIPTION
Is this big enough to require PLIP or just enhancement?

Currently, updating theme metadata for active theme requires deactivating and activating theme while just "reactivating" theme would be enough. For me, with some plone.app.theming plugins (mainly collective.themesitesetup), it's not just the metadata, but "updating theme" may also update content types and translations.

I know that there are already a lot of buttons and difference between "Update" and "Clear cache" may not be clear.

I did not add any "real code", but update just calls theme activation again.