### PR TITLE
Make diazo.debug work with DIAZO_ALWAYS_CACHE_RULES

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Make diazo.debug work again when DIAZO_ALWAYS_CACHE_RULES is set.
+  [ale-rt]
 
 
 1.3.3 (2016-12-02)

--- a/src/plone/app/theming/tests/test_transform.py
+++ b/src/plone/app/theming/tests/test_transform.py
@@ -1,24 +1,25 @@
 # -*- coding: utf-8 -*-
-from Products.CMFCore.Expression import Expression
-from Products.CMFCore.Expression import getExprContext
-from Products.CMFCore.utils import getToolByName
 from diazo.compiler import compile_theme
 from lxml import etree
 from os import environ
-from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
 from plone.app.theming.interfaces import IThemeSettings
 from plone.app.theming.testing import THEMING_FUNCTIONAL_TESTING
 from plone.app.theming.transform import ThemeTransform
-from plone.app.theming.utils import InternalResolver
-from plone.app.theming.utils import PythonResolver
 from plone.app.theming.utils import applyTheme
 from plone.app.theming.utils import getTheme
+from plone.app.theming.utils import InternalResolver
+from plone.app.theming.utils import PythonResolver
 from plone.app.theming.utils import resolvePythonURL
 from plone.registry.interfaces import IRegistry
 from plone.testing.z2 import Browser
+from Products.CMFCore.Expression import Expression
+from Products.CMFCore.Expression import getExprContext
+from Products.CMFCore.utils import getToolByName
 from urllib2 import HTTPError
 from zope.component import getUtility
+
 import Globals
 import os.path
 import re
@@ -100,7 +101,7 @@ class TestCase(unittest.TestCase):
         # and clean it up
         env_var_backup = environ.pop(var_name, None)
 
-        transform = ThemeTransform(None, None)
+        transform = ThemeTransform(None, {})
         # This evaluates to True because we set
         # Globals.DevelopmentMode to True in the test setup
         self.assertTrue(transform.develop_theme())
@@ -108,6 +109,10 @@ class TestCase(unittest.TestCase):
         # But we can anyway force the cache
         environ[var_name] = 'true'
         self.assertFalse(transform.develop_theme())
+
+        # If we require to debug.diazo the variable will be ignored
+        transform = ThemeTransform(None, {'diazo.debug': '1'})
+        self.assertTrue(transform.develop_theme())
 
         # Then we reset our env variables before leaving
         if env_had_var:

--- a/src/plone/app/theming/transform.py
+++ b/src/plone/app/theming/transform.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from lxml import etree
+from os import environ
 from plone.app.theming.interfaces import IThemingLayer
 from plone.app.theming.utils import compileThemeTransform
 from plone.app.theming.utils import findContext
@@ -8,13 +9,14 @@ from plone.app.theming.utils import prepareThemeParameters
 from plone.app.theming.utils import theming_policy
 from plone.app.theming.zmi import patch_zmi
 from plone.transformchain.interfaces import ITransform
-from os import environ
 from repoze.xmliter.utils import getHTMLSerializer
 from zope.component import adapter
-from zope.interface import Interface
 from zope.interface import implementer
+from zope.interface import Interface
+
 import Globals
 import logging
+
 
 # Disable theming of ZMI
 patch_zmi()
@@ -35,16 +37,27 @@ class ThemeTransform(object):
         self.published = published
         self.request = request
 
-    def develop_theme(self):
-        ''' Check if the theme should be recompiled every time the
-        transform is applied
+    def debug_theme(self):
+        ''' Check if the theme should be debugged
+        We will debug the theme
+        when we have a truish diazo.debug parameter in the request
         '''
-        if Globals.DevelopmentMode:
-            if environ.get('DIAZO_ALWAYS_CACHE_RULES'):
-                return False
-            else:
-                return True
-        return False
+        if not Globals.DevelopmentMode:
+            return False
+        diazo_debug = self.request.get('diazo.debug', '').lower()
+        return diazo_debug in ('1', 'y', 'yes', 't', 'true')
+
+    def develop_theme(self):
+        ''' Check if the theme should be recompiled
+        every time the transform is applied
+        '''
+        if not Globals.DevelopmentMode:
+            return False
+        if self.debug_theme():
+            return True
+        if environ.get('DIAZO_ALWAYS_CACHE_RULES'):
+            return False
+        return True
 
     def setupTransform(self, runtrace=False):
         DevelopmentMode = self.develop_theme()
@@ -127,11 +140,7 @@ class ThemeTransform(object):
             return None
 
         DevelopmentMode = Globals.DevelopmentMode
-        diazo_debug = self.request.get('diazo.debug', '').lower()
-        runtrace = (
-            DevelopmentMode
-            and diazo_debug in ('1', 'y', 'yes', 't', 'true')
-        )
+        runtrace = self.debug_theme()
 
         try:
             etree.clear_error_log()


### PR DESCRIPTION
Superseeds #118, for which I am not able to trigger the tests