### PR TITLE
[a11y] Added role attribute for portalMessage

### DIFF
--- a/news/151.bugfix
+++ b/news/151.bugfix
@@ -1,0 +1,2 @@
+a11y: Added role attribute for portalMessage
+[nzambello]

--- a/src/plone/app/theming/browser/controlpanel.pt
+++ b/src/plone/app/theming/browser/controlpanel.pt
@@ -51,7 +51,7 @@
     <div tal:replace="structure provider:plone.toolbar" />
 
     <aside id="global_statusmessage">
-      <div class="portalMessage info">
+      <div class="portalMessage info" role="status">
         <strong i18n:translate="">Note</strong>
         <span tal:omit-tag="" i18n:translate="description_notheme_controlpanel">
           Please note that this control panel page will never be themed.

--- a/src/plone/app/theming/browser/mapper.pt
+++ b/src/plone/app/theming/browser/mapper.pt
@@ -69,7 +69,8 @@
     <aside id="global_statusmessage">
       <tal:message tal:content="structure provider:plone.globalstatusmessage"/>
       <div class="portalMessage warning"
-        tal:condition="python:view.active and view.editable">
+           role="status"
+           tal:condition="python:view.active and view.editable">
         <strong i18n:translate="">Warning</strong>
         <span tal:omit-tag="" i18n:translate="theming_mapper_warning_live">
             This theme is currently active. Any changes made will be immediately
@@ -77,7 +78,8 @@
         </span>
       </div>
       <div class="portalMessage warning"
-        tal:condition="not: view/editable">
+           role="status"
+           tal:condition="not: view/editable">
         <strong i18n:translate="">Warning</strong>
         <span tal:omit-tag="" i18n:translate="theming_mapper_warning_cannot_edit">
             This is a built-in theme, and cannot be edited.


### PR DESCRIPTION
Screen readers could now see and read correctly alerts/status messages.