### PR TITLE
Load zcml of plone.resource.

### DIFF
--- a/news/2952.bugfix
+++ b/news/2952.bugfix
@@ -1,0 +1,2 @@
+Load zcml of ``plone.resource`` for our use of the ``plone:static`` directive.
+[maurits]

--- a/src/plone/app/theming/configure.zcml
+++ b/src/plone/app/theming/configure.zcml
@@ -6,6 +6,7 @@
     xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="plone">
 
+    <include package="plone.resource" />
     <include package="plone.staticresources" />
     <include package="plone.resourceeditor" />
     <include package="plone.transformchain" />


### PR DESCRIPTION
This is for our use of the `plone:static` directive.
See https://github.com/plone/Products.CMFPlone/issues/2952