### PR TITLE
Do not call processInputs.

### DIFF
--- a/news/171.bugfix
+++ b/news/171.bugfix
@@ -1,0 +1,3 @@
+Do not call ``processInputs``.
+It is not needed since Zope 4, and not existing in Zope 5.
+[maurits]

--- a/src/plone/app/theming/browser/controlpanel.py
+++ b/src/plone/app/theming/browser/controlpanel.py
@@ -20,7 +20,6 @@ from plone.registry.interfaces import IRegistry
 from plone.resource.utils import queryResourceDirectory
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import ILinkSchema
-from Products.Five.browser.decode import processInputs
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -106,7 +105,6 @@ class ThemingControlpanel(BrowserView):
 
     def update(self):
         # XXX: complexity too high: refactoring needed
-        processInputs(self.request)
         self._setup()
         self.errors = {}
         form = self.request.form

--- a/src/plone/app/theming/browser/mapper.py
+++ b/src/plone/app/theming/browser/mapper.py
@@ -17,7 +17,6 @@ from plone.subrequest import subrequest
 from Products.CMFCore.utils import _getAuthenticatedUser
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.resources import add_bundle_on_request
-from Products.Five.browser.decode import processInputs
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
 from repoze.xmliter.utils import getHTMLSerializer
@@ -61,7 +60,6 @@ class ThemeMapper(BrowserView):
 
     def setup(self):
         self.request.response.setHeader('X-Theme-Disabled', '1')
-        processInputs(self.request)
 
         self.resourceDirectory = self.context
         self.theme = getThemeFromResourceDirectory(self.context)
@@ -218,9 +216,6 @@ class ThemeMapper(BrowserView):
         - a query string parameter ``title`` can be set to give a new page
           title
         """
-
-        processInputs(self.request)
-
         path = self.request.form.get('path', None)
         theme = self.request.form.get('theme', 'off')
         links = self.request.form.get('links', None)


### PR DESCRIPTION
It is not needed since Zope 4, and not existing in Zope 5.
Fixes https://github.com/plone/plone.app.theming/issues/171