### PR TITLE
Custom css view

### DIFF
--- a/news/178.feature
+++ b/news/178.feature
@@ -1,0 +1,3 @@
+Add custom CSS settings and view to theming control panel
+depends on https://github.com/plone/Products.CMFPlone/pull/3089
+[MrTango]

--- a/news/179.bugfix
+++ b/news/179.bugfix
@@ -1,0 +1,1 @@
+fix hostnameBlacklist (Theming ControlPanel) in Py3 [MrTango]

--- a/src/plone/app/theming/browser/configure.zcml
+++ b/src/plone/app/theming/browser/configure.zcml
@@ -54,4 +54,11 @@
         permission="plone.app.controlpanel.Themes"
         />
 
+    <browser:page
+        name="custom.css"
+        for="*"
+        class=".custom_css.CustomCSSView"
+        permission="zope.Public"
+        />
+
 </configure>

--- a/src/plone/app/theming/browser/controlpanel.pt
+++ b/src/plone/app/theming/browser/controlpanel.pt
@@ -584,6 +584,35 @@
                     </div>
 
                 </fieldset>
+                <fieldset>
+                    <legend i18n:translate="">Custom Styles</legend>
+                    <p i18n:translate="description_custom_css_styles">
+                    </p>
+
+                    <div
+                        tal:define="error errors/custom_css | nothing;
+                                    custom_css view/theme_settings/custom_css | python: '';
+                                    custom_css python:request.get('custom_css', custom_css)"
+                        tal:attributes="class python:'field error' if error else 'field'">
+
+                        <label for="custom_css" i18n:translate="label_custom_css">Custom CSS</label>
+                        <div class="formHelp" i18n:translate="help_custom_css">
+                            Define your own custom CSS in the field below. This is a good place for quick customizations of things like colors and the toolbar. Definitions here will override previously defined CSS of Plone. Please use this only for small customizations, as it is hard keep track of changes here. For bigger changes you most likely want to customize a full theme and make your changes there.
+                        </div>
+
+                        <div class="errorMessage" tal:content="error" tal:condition="error" />
+
+                        <textarea
+                            name="custom_css:lines"
+                            id="custom_css"
+                            rows="40"
+                            cols="160"
+                            placeholder="Put your plain css..."
+                            tal:content="custom_css"
+                            ></textarea>
+
+                    </div>
+                </fieldset>
             </div>
 
 

--- a/src/plone/app/theming/browser/controlpanel.pt
+++ b/src/plone/app/theming/browser/controlpanel.pt
@@ -460,7 +460,7 @@
                     <div
                         tal:define="error errors/hostnameBlacklist | nothing;
                                     hostnameBlacklist view/theme_settings/hostnameBlacklist | python:[];
-                                    hostnameBlacklist python:request.get('hostnameBlacklist', hostnameBlacklist)"
+                                    hostnameBlacklist python: view.hostname_blacklist or hostnameBlacklist"
                         tal:attributes="class python:'field error' if error else 'field'">
 
                         <label for="hostnameBlacklist" i18n:translate="label_hostname_blacklist">Unthemed host names</label>
@@ -481,7 +481,7 @@
                             id="hostnameBlacklist"
                             rows="5"
                             cols="50"
-                            tal:content="python:'\n'.join(hostnameBlacklist)"
+                            tal:content="python: '\n'.join(hostnameBlacklist)"
                             ></textarea>
 
                     </div>

--- a/src/plone/app/theming/browser/controlpanel.pt
+++ b/src/plone/app/theming/browser/controlpanel.pt
@@ -599,11 +599,14 @@
                         <div class="formHelp" i18n:translate="help_custom_css">
                             Define your own custom CSS in the field below. This is a good place for quick customizations of things like colors and the toolbar. Definitions here will override previously defined CSS of Plone. Please use this only for small customizations, as it is hard keep track of changes here. For bigger changes you most likely want to customize a full theme and make your changes there.
                         </div>
+                        <div class="theming_doc_link">
+                            <p><a href="https://docs.plone.org/adapt-and-extend/theming" target="_blank" i18n:translate="label_theming_doc_link">Theming documentation</a></p>
+                        </div>
 
                         <div class="errorMessage" tal:content="error" tal:condition="error" />
 
                         <textarea
-                            name="custom_css:lines"
+                            name="custom_css"
                             id="custom_css"
                             rows="40"
                             cols="160"

--- a/src/plone/app/theming/browser/controlpanel.py
+++ b/src/plone/app/theming/browser/controlpanel.py
@@ -51,6 +51,11 @@ class ThemingControlpanel(BrowserView):
         """
         return getSite().absolute_url()
 
+    @property
+    def hostname_blacklist(self):
+        hostname_blacklist = self.request.get('hostnameBlacklist', [])
+        return [host.decode() for host in hostname_blacklist]
+
     def __call__(self):
         self.pskin = getToolByName(self.context, 'portal_skins')
 
@@ -165,8 +170,6 @@ class ThemingControlpanel(BrowserView):
             prefix = form.get('absolutePrefix', None)
             doctype = str(form.get('doctype', ""))
 
-            hostnameBlacklist = form.get('hostnameBlacklist', [])
-
             parameterExpressions = {}
             parameterExpressionsList = form.get('parameterExpressions', [])
 
@@ -200,8 +203,7 @@ class ThemingControlpanel(BrowserView):
                 self.theme_settings.rules = rules
                 self.theme_settings.absolutePrefix = prefix
                 self.theme_settings.parameterExpressions = parameterExpressions
-                self.theme_settings.hostnameBlacklist = [
-                    str(bl) for bl in hostnameBlacklist]
+                self.theme_settings.hostnameBlacklist = self.hostname_blacklist
                 self.theme_settings.custom_css = str(custom_css)
                 self.theme_settings.doctype = doctype
 

--- a/src/plone/app/theming/browser/controlpanel.py
+++ b/src/plone/app/theming/browser/controlpanel.py
@@ -58,7 +58,6 @@ class ThemingControlpanel(BrowserView):
 
     def __call__(self):
         self.pskin = getToolByName(self.context, 'portal_skins')
-
         if self.update():
             return self.index()
         return ''
@@ -191,7 +190,7 @@ class ThemingControlpanel(BrowserView):
             markSpecialLinks = form.get('markSpecialLinks', None)
             extLinksOpenInNewWindow = form.get('extLinksOpenInNewWindow', None)
 
-            custom_css = form.get('custom_css', '')
+            custom_css = form.get('custom_css', b'')
 
             if not self.errors:
                 # Trigger onDisabled() on plugins if theme was active

--- a/src/plone/app/theming/browser/controlpanel.py
+++ b/src/plone/app/theming/browser/controlpanel.py
@@ -19,6 +19,7 @@ from plone.memoize.instance import memoize
 from plone.registry.interfaces import IRegistry
 from plone.resource.utils import queryResourceDirectory
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import safe_unicode
 from Products.CMFPlone.interfaces import ILinkSchema
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import getMultiAdapter
@@ -187,6 +188,8 @@ class ThemingControlpanel(BrowserView):
             markSpecialLinks = form.get('markSpecialLinks', None)
             extLinksOpenInNewWindow = form.get('extLinksOpenInNewWindow', None)
 
+            custom_css = form.get('custom_css', '')
+
             if not self.errors:
                 # Trigger onDisabled() on plugins if theme was active
                 # previously and rules were changed
@@ -197,7 +200,9 @@ class ThemingControlpanel(BrowserView):
                 self.theme_settings.rules = rules
                 self.theme_settings.absolutePrefix = prefix
                 self.theme_settings.parameterExpressions = parameterExpressions
-                self.theme_settings.hostnameBlacklist = hostnameBlacklist
+                self.theme_settings.hostnameBlacklist = [
+                    str(bl) for bl in hostnameBlacklist]
+                self.theme_settings.custom_css = str(custom_css)
                 self.theme_settings.doctype = doctype
 
                 # Theme base settings

--- a/src/plone/app/theming/browser/controlpanel.py
+++ b/src/plone/app/theming/browser/controlpanel.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from AccessControl import Unauthorized
+from datetime import datetime
 from plone.app.theming.interfaces import _
 from plone.app.theming.interfaces import DEFAULT_THEME_FILENAME
 from plone.app.theming.interfaces import IThemeSettings
@@ -203,6 +204,8 @@ class ThemingControlpanel(BrowserView):
                 self.theme_settings.absolutePrefix = prefix
                 self.theme_settings.parameterExpressions = parameterExpressions
                 self.theme_settings.hostnameBlacklist = self.hostname_blacklist
+                if custom_css != self.theme_settings.custom_css:
+                    self.theme_settings.custom_css_timestamp = datetime.now()
                 self.theme_settings.custom_css = str(custom_css)
                 self.theme_settings.doctype = doctype
 

--- a/src/plone/app/theming/browser/custom_css.py
+++ b/src/plone/app/theming/browser/custom_css.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from plone.app.theming.interfaces import IThemeSettings
+from plone.registry.interfaces import IRegistry
+from Products.Five.browser import BrowserView
+from zope.component import getUtility
+
+
+class CustomCSSView(BrowserView):
+    """
+    Renders custom CSS stored in registry
+    """
+
+    def __call__(self):
+
+        registry = getUtility(IRegistry)
+        theme_settings = registry.forInterface(IThemeSettings, False)
+        self.request.response.setHeader('Content-Type', 'text/css')
+        custom_css = theme_settings.custom_css
+        return custom_css

--- a/src/plone/app/theming/browser/custom_css.py
+++ b/src/plone/app/theming/browser/custom_css.py
@@ -3,6 +3,7 @@ from plone.app.theming.interfaces import IThemeSettings
 from plone.registry.interfaces import IRegistry
 from Products.Five.browser import BrowserView
 from zope.component import getUtility
+from plone.app.caching.operations.utils import formatDateTime
 
 
 class CustomCSSView(BrowserView):
@@ -14,6 +15,13 @@ class CustomCSSView(BrowserView):
 
         registry = getUtility(IRegistry)
         theme_settings = registry.forInterface(IThemeSettings, False)
-        self.request.response.setHeader('Content-Type', 'text/css')
+        self.request.response.setHeader(
+            'Content-Type',
+            'text/css; charset=utf-8',
+        )
+        self.request.response.setHeader(
+            'Last-Modified',
+            formatDateTime(theme_settings.custom_css_timestamp),
+        )
         custom_css = theme_settings.custom_css
         return custom_css

--- a/src/plone/app/theming/interfaces.py
+++ b/src/plone/app/theming/interfaces.py
@@ -139,7 +139,7 @@ class IThemeSettings(Interface):
         ),
         value_type=schema.TextLine(),
         required=False,
-        default=[u"127.0.0.1"],
+        default=["127.0.0.1"],
     )
 
     parameterExpressions = schema.Dict(
@@ -169,6 +169,24 @@ class IThemeSettings(Interface):
         ),
         required=False,
         default="",
+    )
+
+    custom_css = schema.SourceText(
+        title=_(
+            u'Custom CSS',
+        ),
+        description=_(
+            'help_custom_css',
+            u'Define your own custom CSS in the field below. This is a good '
+            u'place for quick customizations of things like colors and the '
+            u'toolbar. Definitions here will override previously defined CSS '
+            u'of Plone. Please use this only for small customizations, as it '
+            u'is hard keep track of changes here. For bigger changes you most '
+            u'likely want to customize a full theme and make your changes '
+            u'there.',
+        ),
+        default=u"",
+        required=False,
     )
 
 

--- a/src/plone/app/theming/interfaces.py
+++ b/src/plone/app/theming/interfaces.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime
 from plone.resource.manifest import ManifestFormat
 from zope import schema
 from zope.i18nmessageid import MessageFactory
@@ -24,6 +25,9 @@ MANIFEST_FORMAT = ManifestFormat(
 )
 
 THEME_EXTENSIONS = frozenset(['html', 'htm'])
+
+def get_default_custom_css_timestamp():
+    return datetime.now()
 
 
 class ITheme(Interface):
@@ -197,6 +201,7 @@ class IThemeSettings(Interface):
             u'Time stamp when the custom CSS was changed. '
             u'Used to generate custom.css with timestamp in URL.',
         ),
+        defaultFactory=get_default_custom_css_timestamp,
         required=False,
     )
 

--- a/src/plone/app/theming/interfaces.py
+++ b/src/plone/app/theming/interfaces.py
@@ -189,6 +189,17 @@ class IThemeSettings(Interface):
         required=False,
     )
 
+    custom_css_timestamp = schema.Datetime(
+        title=_(
+            u'Custom CSS Timestamp',
+        ),
+        description=_(
+            u'Time stamp when the custom CSS was changed. '
+            u'Used to generate custom.css with timestamp in URL.',
+        ),
+        required=False,
+    )
+
 
 class IThemingLayer(Interface):
     """Browser layer used to indicate that plone.app.theming is installed


### PR DESCRIPTION
Add custom css fields to theming controlpanel, which will be rendered by the custom.css view and inserted into the header after the Diazo bundle. Needs depends on https://github.com/plone/Products.CMFPlone/pull/3089