### PR TITLE
Fix error on Py 3 with nonascii subrequest.

### DIFF
--- a/news/162.bugfix
+++ b/news/162.bugfix
@@ -1,0 +1,4 @@
+Fix error on Python 3 with nonascii subrequest.
+The subrequest would succeed, but the non-ascii would be ugly.
+Fixes `issue 3069 <https://github.com/plone/Products.CMFPlone/issues/3068>`_ and `issue 162 <https://github.com/plone/plone.app.theming/issues/162>`_.
+[maurits]

--- a/src/plone/app/theming/tests/french.html
+++ b/src/plone/app/theming/tests/french.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+    <!-- With a charset, the error in test_include_non_ascii does not happen. -->
+    <!-- <meta charset="utf-8"/> -->
+    <title>Title</title>
+</head>
+<body>
+    <div id="content">Actualités</div>
+</body>

--- a/src/plone/app/theming/tests/nonascii.html
+++ b/src/plone/app/theming/tests/nonascii.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+    <title>Title</title>
+</head>
+<body>
+    <div id="content">(placeholder)</div>
+</body>

--- a/src/plone/app/theming/tests/nonascii.xml
+++ b/src/plone/app/theming/tests/nonascii.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules xmlns="http://namespaces.plone.org/diazo" xmlns:css="http://namespaces.plone.org/diazo/css">
+
+    <theme href="python://plone.app.theming.tests/french.html" />
+
+    <replace content='//*[@id="content"]/text()' css:theme-children='#content' href="/french" />
+
+</rules>

--- a/src/plone/app/theming/tests/test_transform.py
+++ b/src/plone/app/theming/tests/test_transform.py
@@ -23,6 +23,7 @@ from zope.component import getUtility
 
 import os.path
 import re
+import six
 import transaction
 import unittest
 
@@ -812,6 +813,44 @@ class TestCase(unittest.TestCase):
         browser.open(portal['subfolder'].absolute_url())
         self.assertTrue('<div id="alpha">Number one</div>' in browser.contents)
         self.assertTrue('<div id="beta">Number one</div>' in browser.contents)
+
+    def test_include_non_ascii(self):
+        # A Diazo theme with non-ascii subrequest can show characters wrong with Python 3.
+        # See https://github.com/plone/Products.CMFPlone/issues/3068
+        # These are the same French characters:
+        # 'Actualités'
+        # b'Actualit\xc3\xa9s'
+        # u'Actualit\xe9s'
+        # 'Actualit&#195;&#169;s'
+
+        app = self.layer['app']
+        portal = self.layer['portal']
+
+        setRoles(portal, TEST_USER_ID, ('Manager',))
+
+        # Create some test content in the portal root
+        here = os.path.split(__file__)[0]
+        with open(os.path.join(here, 'french.html')) as french:
+            portal.manage_addDTMLMethod('french', file=french)
+
+        # Set up transformation
+        self.settings.rules = u'python://plone.app.theming/tests/nonascii.xml'
+        self.settings.enabled = True
+
+        transaction.commit()
+
+        browser = Browser(app)
+
+        # At the root if the site, we should pick up 'one' for alpha (absolute
+        # path, relative to site root) and 'two' for beta (relative path,
+        # relative to current directory)
+
+        browser.open(portal.absolute_url())
+        # browser.contents is always string.  On Py 2 this means bytes, on Py 3 text.
+        if six.PY2:
+            self.assertIn(b'<div id="content">Actualit\xc3\xa9s</div>', browser.contents)
+        else:
+            self.assertIn(u'<div id="content">Actualit\xe9s</div>', browser.contents)
 
     def test_css_js_includes(self):
 

--- a/src/plone/app/theming/tests/test_transform.py
+++ b/src/plone/app/theming/tests/test_transform.py
@@ -886,9 +886,12 @@ class TestCase(unittest.TestCase):
         browser = Browser(app)
         browser.open(portal.absolute_url())
 
-        self.assertTrue(
-            '''<div>N\xc3\xbamero uno</div>'''
-            in browser.contents)
+        # browser.contents is always string.  On Py 2 this means bytes, on Py 3 text.
+        if six.PY2:
+            self.assertIn(b'<div>N\xc3\xbamero uno</div>', browser.contents)
+        else:
+            self.assertIn(u'<div>N\xfamero uno</div>', browser.contents)
+
 
     def test_theme_enabled_query_string_debug_switch(self):
         app = self.layer['app']

--- a/src/plone/app/theming/tests/test_transform.py
+++ b/src/plone/app/theming/tests/test_transform.py
@@ -830,7 +830,7 @@ class TestCase(unittest.TestCase):
 
         # Create some test content in the portal root
         here = os.path.split(__file__)[0]
-        with open(os.path.join(here, 'french.html')) as french:
+        with open(os.path.join(here, 'french.html'), "rb") as french:
             portal.manage_addDTMLMethod('french', file=french)
 
         # Set up transformation

--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -149,10 +149,11 @@ class InternalResolver(etree.Resolver):
             # e.g. charset=utf-8
             encoding = encoding.split('=', 1)[1].strip()
         result = result.decode(encoding)
-        # Note: at first the xmlcharrefreplace was only done on Python 2,
-        # but Python 3 needs it as well.
-        # See https://github.com/plone/Products.CMFPlone/issues/3068
-        result = result.encode('ascii', 'xmlcharrefreplace')
+        if six.PY2 or content_type == 'text/html':
+            # Note: at first the xmlcharrefreplace was only done on Python 2,
+            # but Python 3 needs it as well, but only for html.
+            # See https://github.com/plone/Products.CMFPlone/issues/3068
+            result = result.encode('ascii', 'xmlcharrefreplace')
 
         if content_type in ('text/javascript', 'application/x-javascript'):
             result = ''.join([

--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -149,8 +149,10 @@ class InternalResolver(etree.Resolver):
             # e.g. charset=utf-8
             encoding = encoding.split('=', 1)[1].strip()
         result = result.decode(encoding)
-        if six.PY2:
-            result = result.encode('ascii', 'xmlcharrefreplace')
+        # Note: at first the xmlcharrefreplace was only done on Python 2,
+        # but Python 3 needs it as well.
+        # See https://github.com/plone/Products.CMFPlone/issues/3068
+        result = result.encode('ascii', 'xmlcharrefreplace')
 
         if content_type in ('text/javascript', 'application/x-javascript'):
             result = ''.join([


### PR DESCRIPTION
The subrequest would succeed, but the non-ascii would be ugly.
Added a test for this.
With a French example, we expect "Actualités" but get "ActualitÃ©s".
Or with a Greek example we expect "Αρχική Σελίδα" but get "Î\x91Ï\x81Ï\x87Î¹ÎºÎ® Î£ÎµÎ»Î¯Î´Î±".
(This may or may not be readable in this commit message...)
[Edit: on GitHub it looks as ugly as I expect it to be.]

Fixes https://github.com/plone/Products.CMFPlone/issues/3068 and https://github.com/plone/plone.app.theming/issues/162

This partially undoes https://github.com/plone/plone.app.theming/pull/146 and is basically the same as this fix from 2011: https://github.com/plone/plone.app.theming/commit/1298857e0ec8c4846807fc6b2504b686f5384918
That fix was still there, but only executed on Python 2.  Now also Python 3.
