### PR TITLE
Call processInputs when available, fixing WrongType

### DIFF
--- a/news/183.bugfix
+++ b/news/183.bugfix
@@ -1,0 +1,4 @@
+Fix various ``WrongType`` exceptions when saving the control panel.
+This was introduces by the ``processInputs`` change in version 4.0.5.
+See `issue 183 <https://github.com/plone/plone.app.theming/issues/183>`_.
+[maurits]

--- a/src/plone/app/theming/browser/controlpanel.pt
+++ b/src/plone/app/theming/browser/controlpanel.pt
@@ -460,7 +460,7 @@
                     <div
                         tal:define="error errors/hostnameBlacklist | nothing;
                                     hostnameBlacklist view/theme_settings/hostnameBlacklist | python:[];
-                                    hostnameBlacklist python: view.hostname_blacklist or hostnameBlacklist"
+                                    hostnameBlacklist python:request.get('hostnameBlacklist', hostnameBlacklist)"
                         tal:attributes="class python:'field error' if error else 'field'">
 
                         <label for="hostnameBlacklist" i18n:translate="label_hostname_blacklist">Unthemed host names</label>
@@ -481,7 +481,7 @@
                             id="hostnameBlacklist"
                             rows="5"
                             cols="50"
-                            tal:content="python: '\n'.join(hostnameBlacklist)"
+                            tal:content="python:'\n'.join(hostnameBlacklist)"
                             ></textarea>
 
                     </div>

--- a/src/plone/app/theming/browser/controlpanel.py
+++ b/src/plone/app/theming/browser/controlpanel.py
@@ -22,6 +22,7 @@ from plone.resource.utils import queryResourceDirectory
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from Products.CMFPlone.interfaces import ILinkSchema
+from Products.Five.browser.decode import processInputs
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -111,6 +112,7 @@ class ThemingControlpanel(BrowserView):
 
     def update(self):
         # XXX: complexity too high: refactoring needed
+        processInputs(self.request)
         self._setup()
         self.errors = {}
         form = self.request.form

--- a/src/plone/app/theming/browser/controlpanel.py
+++ b/src/plone/app/theming/browser/controlpanel.py
@@ -22,7 +22,6 @@ from plone.resource.utils import queryResourceDirectory
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from Products.CMFPlone.interfaces import ILinkSchema
-from Products.Five.browser.decode import processInputs
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -33,6 +32,14 @@ from zope.schema.interfaces import IVocabularyFactory
 import logging
 import six
 import zipfile
+
+
+try:
+    # Zope 4
+    from Products.Five.browser.decode import processInputs
+except ImportError:
+    # Zope 5
+    processInputs = None
 
 
 logger = logging.getLogger('plone.app.theming')
@@ -112,7 +119,8 @@ class ThemingControlpanel(BrowserView):
 
     def update(self):
         # XXX: complexity too high: refactoring needed
-        processInputs(self.request)
+        if processInputs is not None:
+            processInputs(self.request)
         self._setup()
         self.errors = {}
         form = self.request.form

--- a/src/plone/app/theming/browser/controlpanel.py
+++ b/src/plone/app/theming/browser/controlpanel.py
@@ -60,11 +60,6 @@ class ThemingControlpanel(BrowserView):
         """
         return getSite().absolute_url()
 
-    @property
-    def hostname_blacklist(self):
-        hostname_blacklist = self.request.get('hostnameBlacklist', [])
-        return [host.decode() for host in hostname_blacklist]
-
     def __call__(self):
         self.pskin = getToolByName(self.context, 'portal_skins')
         if self.update():
@@ -180,6 +175,8 @@ class ThemingControlpanel(BrowserView):
             prefix = form.get('absolutePrefix', None)
             doctype = str(form.get('doctype', ""))
 
+            hostnameBlacklist = form.get('hostnameBlacklist', [])
+
             parameterExpressions = {}
             parameterExpressionsList = form.get('parameterExpressions', [])
 
@@ -213,7 +210,7 @@ class ThemingControlpanel(BrowserView):
                 self.theme_settings.rules = rules
                 self.theme_settings.absolutePrefix = prefix
                 self.theme_settings.parameterExpressions = parameterExpressions
-                self.theme_settings.hostnameBlacklist = self.hostname_blacklist
+                self.theme_settings.hostnameBlacklist = hostnameBlacklist
                 if custom_css != self.theme_settings.custom_css:
                     self.theme_settings.custom_css_timestamp = datetime.now()
                 self.theme_settings.custom_css = custom_css

--- a/src/plone/app/theming/browser/controlpanel.py
+++ b/src/plone/app/theming/browser/controlpanel.py
@@ -216,7 +216,7 @@ class ThemingControlpanel(BrowserView):
                 self.theme_settings.hostnameBlacklist = self.hostname_blacklist
                 if custom_css != self.theme_settings.custom_css:
                     self.theme_settings.custom_css_timestamp = datetime.now()
-                self.theme_settings.custom_css = str(custom_css)
+                self.theme_settings.custom_css = custom_css
                 self.theme_settings.doctype = doctype
 
                 # Theme base settings

--- a/src/plone/app/theming/browser/mapper.py
+++ b/src/plone/app/theming/browser/mapper.py
@@ -17,6 +17,7 @@ from plone.subrequest import subrequest
 from Products.CMFCore.utils import _getAuthenticatedUser
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.resources import add_bundle_on_request
+from Products.Five.browser.decode import processInputs
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
 from repoze.xmliter.utils import getHTMLSerializer
@@ -60,6 +61,7 @@ class ThemeMapper(BrowserView):
 
     def setup(self):
         self.request.response.setHeader('X-Theme-Disabled', '1')
+        processInputs(self.request)
 
         self.resourceDirectory = self.context
         self.theme = getThemeFromResourceDirectory(self.context)
@@ -216,6 +218,9 @@ class ThemeMapper(BrowserView):
         - a query string parameter ``title`` can be set to give a new page
           title
         """
+
+        processInputs(self.request)
+
         path = self.request.form.get('path', '/')
         theme = self.request.form.get('theme', 'off')
         links = self.request.form.get('links', None)

--- a/src/plone/app/theming/browser/mapper.py
+++ b/src/plone/app/theming/browser/mapper.py
@@ -17,7 +17,6 @@ from plone.subrequest import subrequest
 from Products.CMFCore.utils import _getAuthenticatedUser
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.resources import add_bundle_on_request
-from Products.Five.browser.decode import processInputs
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
 from repoze.xmliter.utils import getHTMLSerializer
@@ -34,6 +33,14 @@ import lxml.html
 import lxml.html.builder
 import os.path
 import six
+
+
+try:
+    # Zope 4
+    from Products.Five.browser.decode import processInputs
+except ImportError:
+    # Zope 5
+    processInputs = None
 
 
 class ThemeMapper(BrowserView):
@@ -61,7 +68,8 @@ class ThemeMapper(BrowserView):
 
     def setup(self):
         self.request.response.setHeader('X-Theme-Disabled', '1')
-        processInputs(self.request)
+        if processInputs is not None:
+            processInputs(self.request)
 
         self.resourceDirectory = self.context
         self.theme = getThemeFromResourceDirectory(self.context)
@@ -218,8 +226,8 @@ class ThemeMapper(BrowserView):
         - a query string parameter ``title`` can be set to give a new page
           title
         """
-
-        processInputs(self.request)
+        if processInputs is not None:
+            processInputs(self.request)
 
         path = self.request.form.get('path', '/')
         theme = self.request.form.get('theme', 'off')

--- a/src/plone/app/theming/configure.zcml
+++ b/src/plone/app/theming/configure.zcml
@@ -27,20 +27,19 @@
         />
 
     <gs:upgradeStep
-        title="Update registry"
-        source="*"
-        destination="1000"
-        handler=".upgrade.update_registry"
-        sortkey="1"
-        profile="plone.app.theming:default"
-        />
-
-    <gs:upgradeStep
         title="Combine Theming control panels"
         source="1000"
         destination="1001"
         handler=".upgrade.update_controlpanel"
         sortkey="2"
+        profile="plone.app.theming:default"
+        />
+
+    <gs:upgradeStep
+        title="Update registry"
+        source="1001"
+        destination="1002"
+        handler=".upgrade.update_registry"
         profile="plone.app.theming:default"
         />
 

--- a/src/plone/app/theming/profiles/default/metadata.xml
+++ b/src/plone/app/theming/profiles/default/metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-    <version>1001</version>
+    <version>1002</version>
     <dependencies>
         <dependency>profile-plone.app.registry:default</dependency>
     </dependencies>

--- a/src/plone/app/theming/tests/test_controlpanel.py
+++ b/src/plone/app/theming/tests/test_controlpanel.py
@@ -39,6 +39,15 @@ class TestControlPanel(unittest.TestCase):
             self.portal.absolute_url() + '/@@theming-controlpanel'
         )
 
+    def test_save_advanced(self):
+        # Simply saving the advanced panel without changes could already give a WrongType error.
+        # See for example https://github.com/plone/plone.app.theming/issues/179
+        # but there are more.
+        self.browser.handleErrors = False
+        self.goto_controlpanel()
+        button = self.browser.getControl(name="form.button.AdvancedSave")
+        button.click()
+
     def test_create_theme(self):
         pass
     #     self.goto_controlpanel()
@@ -75,7 +84,7 @@ Content-Disposition: form-data; name="file"; filename="Screen Shot 2018-02-16 at
 Content-Type: image/png
 
 
----blah---           
+---blah---
             """,
 # Bug in testbrowser prevents this working
 #            content_type='multipart/form-data; boundary=---blah---'


### PR DESCRIPTION
This fixes issue #183.
I added a test that saves the advanced control panel. And I tested it manually in the browser. Tested in Plone 5.2 on Py 2 and 3, and on Plone 6. All seems well.