### PR TITLE
Fixed deprecation warning for ConfigParser.readfp.

### DIFF
--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -1,0 +1,2 @@
+Fixed deprecation warning for ConfigParser.readfp.
+[maurits]

--- a/src/plone/app/theming/plugins/utils.py
+++ b/src/plone/app/theming/plugins/utils.py
@@ -87,7 +87,11 @@ def getPluginSettings(themeDirectory, plugins=None):
         fp = themeDirectory.openFile(MANIFEST_FILENAME)
         try:
             if six.PY2:
-                parser.readfp(fp)
+                if hasattr(parser, "read_file"):
+                    # backports.configparser
+                    parser.read_file(fp)
+                else:
+                    parser.readfp(fp)
             else:
                 parser.read_string(fp.read().decode())
             for section in parser.sections():

--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -546,7 +546,11 @@ def createThemeFromTemplate(title, description, baseOn='template'):
         if six.PY2:
             fp = target.openFile(MANIFEST_FILENAME)
             try:
-                manifest.readfp(fp)
+                if hasattr(manifest, "read_file"):
+                    # backports.configparser
+                    manifest.read_file(fp)
+                else:
+                    manifest.readfp(fp)
             finally:
                 fp.close()
 


### PR DESCRIPTION
```
DeprecationWarning: This method will be removed in future versions.
Use 'parser.read_file()' instead.
```

The standard ConfigParser on Python 2 does not have the read_file method,
but we have backports.configparser, which *does* have it.
Use the new one when available.