### PR TITLE
Fixed WrongContainedType for hostnameBlackList on Zope 5.

### DIFF
--- a/news/183.bugfix
+++ b/news/183.bugfix
@@ -1,0 +1,3 @@
+Fixed WrongContainedType for hostnameBlackList on Zope 5.
+See also `issue 183 <https://github.com/plone/plone.app.theming/issues/183>`_.
+[maurits]

--- a/src/plone/app/theming/browser/controlpanel.pt
+++ b/src/plone/app/theming/browser/controlpanel.pt
@@ -460,7 +460,7 @@
                     <div
                         tal:define="error errors/hostnameBlacklist | nothing;
                                     hostnameBlacklist view/theme_settings/hostnameBlacklist | python:[];
-                                    hostnameBlacklist python:request.get('hostnameBlacklist', hostnameBlacklist)"
+                                    hostnameBlacklist python: view.hostname_blacklist or hostnameBlacklist"
                         tal:attributes="class python:'field error' if error else 'field'">
 
                         <label for="hostnameBlacklist" i18n:translate="label_hostname_blacklist">Unthemed host names</label>
@@ -481,7 +481,7 @@
                             id="hostnameBlacklist"
                             rows="5"
                             cols="50"
-                            tal:content="python:'\n'.join(hostnameBlacklist)"
+                            tal:content="python: '\n'.join(hostnameBlacklist)"
                             ></textarea>
 
                     </div>

--- a/src/plone/app/theming/browser/controlpanel.py
+++ b/src/plone/app/theming/browser/controlpanel.py
@@ -60,6 +60,13 @@ class ThemingControlpanel(BrowserView):
         """
         return getSite().absolute_url()
 
+    @property
+    def hostname_blacklist(self):
+        hostname_blacklist = self.request.get('hostnameBlacklist', [])
+        if six.PY2:
+            return hostname_blacklist
+        return [host.decode() for host in hostname_blacklist]
+
     def __call__(self):
         self.pskin = getToolByName(self.context, 'portal_skins')
         if self.update():
@@ -175,8 +182,6 @@ class ThemingControlpanel(BrowserView):
             prefix = form.get('absolutePrefix', None)
             doctype = str(form.get('doctype', ""))
 
-            hostnameBlacklist = form.get('hostnameBlacklist', [])
-
             parameterExpressions = {}
             parameterExpressionsList = form.get('parameterExpressions', [])
 
@@ -210,7 +215,7 @@ class ThemingControlpanel(BrowserView):
                 self.theme_settings.rules = rules
                 self.theme_settings.absolutePrefix = prefix
                 self.theme_settings.parameterExpressions = parameterExpressions
-                self.theme_settings.hostnameBlacklist = hostnameBlacklist
+                self.theme_settings.hostnameBlacklist = self.hostname_blacklist
                 if custom_css != self.theme_settings.custom_css:
                     self.theme_settings.custom_css_timestamp = datetime.now()
                 self.theme_settings.custom_css = custom_css

--- a/src/plone/app/theming/browser/controlpanel.py
+++ b/src/plone/app/theming/browser/controlpanel.py
@@ -21,6 +21,7 @@ from plone.registry.interfaces import IRegistry
 from plone.resource.utils import queryResourceDirectory
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
+from Products.CMFPlone.utils import safe_nativestring
 from Products.CMFPlone.interfaces import ILinkSchema
 from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import getMultiAdapter
@@ -63,9 +64,7 @@ class ThemingControlpanel(BrowserView):
     @property
     def hostname_blacklist(self):
         hostname_blacklist = self.request.get('hostnameBlacklist', [])
-        if six.PY2:
-            return hostname_blacklist
-        return [host.decode() for host in hostname_blacklist]
+        return [safe_nativestring(host) for host in hostname_blacklist]
 
     def __call__(self):
         self.pskin = getToolByName(self.context, 'portal_skins')

--- a/src/plone/app/theming/browser/controlpanel.py
+++ b/src/plone/app/theming/browser/controlpanel.py
@@ -64,6 +64,8 @@ class ThemingControlpanel(BrowserView):
     @property
     def hostname_blacklist(self):
         hostname_blacklist = self.request.get('hostnameBlacklist', [])
+        if six.PY2:
+            return hostname_blacklist
         return [safe_nativestring(host) for host in hostname_blacklist]
 
     def __call__(self):


### PR DESCRIPTION
See also https://github.com/plone/plone.app.theming/issues/183.

This reverts commit 9c64d46bf54ebf5259a8ccf400d329991a2cb70a
which was itself a revert of "fix hostnameBlacklist (Theming ControlPanel) in Py3"

In Plone 6 (with Zope 5) this is needed again, because `processInputs` no longer exists.