### PR TITLE
Fail when trying file protocol access in diazo rules

### DIFF
--- a/news/3209.bugfix
+++ b/news/3209.bugfix
@@ -1,0 +1,3 @@
+For increased security, fail when trying file protocol access in diazo rules.
+Also do not resolve entities, and remove processing instructions.
+[maurits]


### PR DESCRIPTION
Also do not resolve entities, and remove processing instructions.
See https://github.com/plone/Products.CMFPlone/issues/3209
This is a potential security problem, but since the theming control panel is only available for Managers (or I guess Site Administrators) we are not making a big deal out of it.  cc @plone/security-team 

I am not sure if the processing instructions really need to be removed, as I don't really understand what they can do, but it sounds like they might be dangerous, and not needed in Diazo.

