### PR TITLE
ensure tests work with restapi installed

### DIFF
--- a/src/plone/app/theming/configure.zcml
+++ b/src/plone/app/theming/configure.zcml
@@ -11,6 +11,7 @@
     <include package="plone.resourceeditor" />
     <include package="plone.transformchain" />
     <include package="plone.app.registry" />
+    <include package="plone.restapi" />
     <include package="diazo" file="diazo-debug.zcml" />
 
     <include package=".browser" />

--- a/src/plone/app/theming/testing.py
+++ b/src/plone/app/theming/testing.py
@@ -5,6 +5,7 @@ from plone.app.testing import PloneSandboxLayer
 from plone.app.testing.layers import FunctionalTesting
 from plone.app.testing.layers import IntegrationTesting
 from zope.configuration import xmlconfig
+from plone.testing import z2
 
 
 class Theming(PloneSandboxLayer):
@@ -18,6 +19,7 @@ class Theming(PloneSandboxLayer):
             plone.app.theming.tests,
             context=configurationContext
         )
+        z2.installProduct(app, "plone.restapi")
 
         # Run the startup hook
         from plone.app.theming.plugins.hooks import onStartup
@@ -26,6 +28,8 @@ class Theming(PloneSandboxLayer):
     def setUpPloneSite(self, portal):
         # install into the Plone site
         applyProfile(portal, 'plone.app.theming:default')
+        #if portal.portal_setup.profileExists('plone.restapi:default'):
+        applyProfile(portal, 'plone.restapi:default')
 
 
 THEMING_FIXTURE = Theming()

--- a/src/plone/app/theming/tests/test_controlpanel.py
+++ b/src/plone/app/theming/tests/test_controlpanel.py
@@ -68,6 +68,7 @@ class TestControlPanel(unittest.TestCase):
             self.portal.absolute_url() + '/portal_resources/themeFileUpload',
             '',
         )
+        # There is a bug in restapi that causes 404 instead - https://github.com/plone/plone.rest/issues/59
         self.assertIn('Status: 200', str(self.browser.headers))
         self.assertIn(
             '{"failure": "error"}',


### PR DESCRIPTION
There was a bug with my previous PR - https://github.com/plone/plone.rest/pull/61. It didn't install plone.restapi so didn't actually test that it works with it installed