### PR TITLE
Use HTML5 meta charset

### DIFF
--- a/news/203.bugfix
+++ b/news/203.bugfix
@@ -1,0 +1,2 @@
+Use HTML5 meta charset.
+[thet]

--- a/src/plone/app/theming/browser/controlpanel.pt
+++ b/src/plone/app/theming/browser/controlpanel.pt
@@ -19,7 +19,7 @@
     <metal:cache tal:replace="structure provider:plone.httpheaders" />
 
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta charset="utf-8" />
 
     <div tal:replace="structure provider:plone.htmlhead" />
     <link tal:replace="structure provider:plone.htmlhead.links" />

--- a/src/plone/app/theming/browser/mapper.pt
+++ b/src/plone/app/theming/browser/mapper.pt
@@ -18,7 +18,7 @@
     <metal:cache tal:replace="structure provider:plone.httpheaders" />
 
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta charset="utf-8" />
 
     <!-- provide this so menu still shows and is styled -->
     <link rel="stylesheet"


### PR DESCRIPTION
Using http-equiv is no longer the only way to specify the character set of an HTML document.

See:
https://github.com/plone/Products.CMFPlone/pull/3332
https://github.com/plone/Products.CMFPlone/pull/2025