### PR TITLE
fix: if there is no rules.xml given, abort early

### DIFF
--- a/news/216.bugfix
+++ b/news/216.bugfix
@@ -1,0 +1,4 @@
+Bugfix: If there is no rules.xml given in a theme, abort transform early. 
+Otherwise, given an open file is given as iterable, the read buffer pointer is empty after this function, but None returned. 
+The new way the read buffer pointer is not touched.
+[jensens, toalba]

--- a/src/plone/app/theming/transform.py
+++ b/src/plone/app/theming/transform.py
@@ -142,10 +142,11 @@ class ThemeTransform:
         """
         # Obtain settings. Do nothing if not found
         policy = theming_policy(self.request)
-        settings = policy.getSettings()
-        if settings is None:
-            return None
         if not policy.isThemeEnabled():
+            return None
+        settings = policy.getSettings()
+        if settings is None or not settings.rules:
+            # if there is no rules file given, do not try to transform
             return None
         result = self.parseTree(result)
         if result is None:


### PR DESCRIPTION
Otherwise, given an open file is given as iterable, the read pointer is empty after this function, but None returned. This way the read pointer is not touched.

this supersedes https://github.com/collective/plonetheme.tokyo/pull/69 and fixes the real cause
cc @santonelli 

Thanks for pair-debugging this @toalba 