### PR TITLE
unify default message

### DIFF
--- a/news/223.bugfix
+++ b/news/223.bugfix
@@ -1,0 +1,2 @@
+Unify default values for translations
+[erral]

--- a/resources/theme/theme1/overrides/plone.app.layout.viewlets.colophon.pt
+++ b/resources/theme/theme1/overrides/plone.app.layout.viewlets.colophon.pt
@@ -12,7 +12,7 @@
            i18n:attributes="title title_built_with_plone;"
            i18n:translate="label_powered_by_plone"
         >
-          Powered by Plone &amp; Python</a>
+          Powered by Plone</a>
       </li>
       <li>
     and Diazo


### PR DESCRIPTION
We already have a different default in CMFPlone, so we unify them both.


See https://github.com/plone/plone.app.layout/pull/347