### PR TITLE
Fix AttributeError: module 'wsgiref' has no attribute 'handlers'

### DIFF
--- a/news/230.bugfix
+++ b/news/230.bugfix
@@ -1,0 +1,2 @@
+Fix AttributeError in ``custom.css``: "module 'wsgiref' has no attribute 'handlers'".
+[maurits]

--- a/src/plone/app/theming/browser/custom_css.py
+++ b/src/plone/app/theming/browser/custom_css.py
@@ -1,11 +1,11 @@
 from plone.app.theming.interfaces import IThemeSettings
 from plone.registry.interfaces import IRegistry
 from Products.Five.browser import BrowserView
+from wsgiref.handlers import format_date_time
 from zope.component import getUtility
 
 import dateutil
 import time
-import wsgiref
 
 
 class CustomCSSView(BrowserView):
@@ -27,6 +27,6 @@ class CustomCSSView(BrowserView):
         # Format a Python datetime object as an RFC1123 date.
         self.request.response.setHeader(
             "Last-Modified",
-            wsgiref.handlers.format_date_time(time.mktime(dt.timetuple())),
+            format_date_time(time.mktime(dt.timetuple())),
         )
         return theme_settings.custom_css

--- a/src/plone/app/theming/tests/test_controlpanel.py
+++ b/src/plone/app/theming/tests/test_controlpanel.py
@@ -86,3 +86,27 @@ Content-Type: image/png
             '{"failure": "error"}',  # TODO: Should be {'success':'create'}
             str(self.browser.contents),
         )
+
+    def test_custom_css(self):
+        # By default custom.css is empty.
+        self.browser.handleErrors = False
+        self.browser.open("custom.css")
+        self.assertEqual(self.browser.contents, "")
+        self.assertEqual(
+            self.browser.headers["Content-Type"],
+            "text/css; charset=utf-8",
+        )
+
+        # Go to the control panel and add custom css.
+        self.goto_controlpanel()
+        css = "body {background-color: blue;}"
+        self.browser.getControl(name="custom_css").value = css
+        self.browser.getControl(name="form.button.AdvancedSave").click()
+
+        # Check that the css is available.
+        self.browser.open("custom.css")
+        self.assertEqual(self.browser.contents, css)
+        self.assertEqual(
+            self.browser.headers["Content-Type"],
+            "text/css; charset=utf-8",
+        )


### PR DESCRIPTION
This problem in `custom.css` is usually hidden if `plone.app.caching` is available. Fixes https://github.com/plone/plone.app.theming/issues/230

And this PR adds the first test for `custom.css`, which indeed shows this problem. This fixes https://github.com/plone/plone.app.theming/issues/190