### PR TITLE
Traverse to theme resources from the portal

### DIFF
--- a/news/142.bugfix
+++ b/news/142.bugfix
@@ -1,0 +1,2 @@
+Traverse to theme resources from the portal. Fix broken theme when rendering accessible content contained in an inaccessible navigation-root. Fixes #142
+[pbauer]

--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -161,13 +161,10 @@ class InternalResolver(etree.Resolver):
 
         context = findContext(request)
         portalState = queryMultiAdapter((context, request), name="plone_portal_state")
-
-        if portalState is None:
-            root = None
-        else:
-            root = portalState.navigation_root()
+        portal = portalState.portal()
 
         if not system_url.startswith("/"):  # only for relative urls
+            root = portalState.navigation_root()
             root_path = root.getPhysicalPath()
             context_path = context.getPhysicalPath()[len(root_path) :]
             if len(context_path) == 0:
@@ -175,7 +172,7 @@ class InternalResolver(etree.Resolver):
             else:
                 system_url = "/{:s}/{:s}".format("/".join(context_path), system_url)
 
-        response = subrequest(system_url, root=root)
+        response = subrequest(system_url, root=portal)
         if response.status != 200:
             LOGGER.error(f"Couldn't resolve {system_url:s}")
             return None


### PR DESCRIPTION
Fix broken theme when rendering accessible content contained in an inaccessible navigation-root. 
Fixes #142