### PR TITLE
Traverse to theme resources from the navigation root again.

### DIFF
--- a/news/236.bugfix
+++ b/news/236.bugfix
@@ -1,0 +1,4 @@
+Traverse to theme resources from the navigation root again.
+Only when this gives an Unauthorized, try it on the portal as a fall back.
+This fixes other use cases of traversing to absolute urls in a theme.
+[maurits]

--- a/src/plone/app/theming/tests/browser.py
+++ b/src/plone/app/theming/tests/browser.py
@@ -1,0 +1,6 @@
+from Products.Five import BrowserView
+
+
+class Title(BrowserView):
+    def __call__(self):
+        return self.context.Title()

--- a/src/plone/app/theming/tests/configure.zcml
+++ b/src/plone/app/theming/tests/configure.zcml
@@ -28,4 +28,18 @@
       permission="zope.Public"
       />
 
+  <browser:page
+      name="test-title"
+      for="*"
+      class=".browser.Title"
+      permission="zope2.View"
+      />
+
+  <browser:page
+      name="test-public-title"
+      for="*"
+      class=".browser.Title"
+      permission="zope.Public"
+      />
+
 </configure>


### PR DESCRIPTION
Fixes https://github.com/plone/plone.app.theming/issues/236

The code reverts to the original code before PR #232, so everything that worked in Plone 6.0.9 should work again.  And it adds a retry in the corner case of a private navigation root where a traversal gives an Unauthorized.

I have added tests, and I think they cover all use cases that we have identified here and in issue #142.
