### PR TITLE
When calling the html serializer pass an encoding

### DIFF
--- a/news/238.bugfix
+++ b/news/238.bugfix
@@ -1,0 +1,1 @@
+Fix an issue with unicode characters happening with lxml 5 [ale-rt]

--- a/src/plone/app/theming/transform.py
+++ b/src/plone/app/theming/transform.py
@@ -13,6 +13,7 @@ from repoze.xmliter.utils import getHTMLSerializer
 from zope.component import adapter
 from zope.interface import implementer
 from zope.interface import Interface
+from ZPublisher.HTTPRequest import default_encoding
 
 import logging
 
@@ -120,7 +121,9 @@ class ThemeTransform:
             return None
 
         try:
-            return getHTMLSerializer(result, pretty_print=False)
+            return getHTMLSerializer(
+                result, pretty_print=False, encoding=default_encoding
+            )
         except (AttributeError, TypeError, etree.ParseError):
             return None
 


### PR DESCRIPTION
Fixes #238

Without passing the encoding the test fails with:

```
AssertionError: '<!DOCTYPE html>\n<html>\n<body>\n<div>à</div>\n</body>\n</html>' != '<!DOCTYPE html>\n<html>\n<body>\n<div>Ã\xa0</div>\n</body>\n</html>'
  <!DOCTYPE html>
  <html>
  <body>
- <div>à</div>
?      ^
+ <div>Ã </div>
?      ^^
  </body>
  </html>
```