### PR TITLE
Update link and label to Theming of Classic UI documentation

### DIFF
--- a/news/248.bugfix
+++ b/news/248.bugfix
@@ -1,0 +1,1 @@
+Update the link and label under Site Setup > Theming > Advanced settings > Custom Styles to Theming of Classic UI at https://6.docs.plone.org/classic-ui/theming/index.html. @stevepiercy

--- a/src/plone/app/theming/browser/controlpanel.pt
+++ b/src/plone/app/theming/browser/controlpanel.pt
@@ -725,10 +725,10 @@
                             Define your own custom CSS in the field below. This is a good place for quick customizations of things like colors and the toolbar. Definitions here will override previously defined CSS of Plone. Please use this only for small customizations, as it is hard to keep track of changes here. For bigger changes you most likely want to customize a full theme and make your changes there.
                         </div>
                         <div class="theming_doc_link">
-                          <p><a href="https://docs.plone.org/adapt-and-extend/theming"
+                          <p><a href="https://6.docs.plone.org/classic-ui/theming/index.html"
                                target="_blank"
                                i18n:translate="label_theming_doc_link"
-                            >Theming documentation</a></p>
+                            >Theming of Classic UI documentation</a></p>
                         </div>
 
                         <div class="errorMessage"


### PR DESCRIPTION
See https://github.com/plone/Products.CMFPlone/pull/4054

While working on the documentation, I found a bug in the control panel that should be corrected either in this PR or a related one in the correct repository, if not this one.

- Visit https://classic.demo.plone.org/@@theming-controlpanel#autotoc-item-autotoc-2 (Site Setup > Theming > Advanced settings > Custom Styles)
- Click the link [Theming documentation](https://docs.plone.org/adapt-and-extend/theming), which goes to a 404.

The correct link and label are [Theming of Classic UI](https://6.docs.plone.org/classic-ui/theming/index.html).

![Screenshot 2024-12-03 at 7 35 42 PM](https://github.com/user-attachments/assets/3439b245-c278-4b3a-8e85-134414ecc04c)
