### PR TITLE
Use is_truthy from plone.base for yes/no alike parameters and remove …

### DIFF
--- a/news/255.technical
+++ b/news/255.technical
@@ -1,5 +1,0 @@
-Unify the usage of parsing yes/no alike parameters.
-
-The following are interpreted as true-ish values: True, 1 and these strings in
-any casing: "y", "yes", "t", "true", "on". Everything else is considered False.
-[thet]

--- a/news/257.technical
+++ b/news/257.technical
@@ -1,0 +1,2 @@
+Use is_truthy from plone.base for yes/no alike parameters.
+[thet]

--- a/src/plone/app/theming/policy.py
+++ b/src/plone/app/theming/policy.py
@@ -3,6 +3,7 @@ from logging import getLogger
 from plone.app.theming import utils
 from plone.app.theming.interfaces import IThemeSettings
 from plone.app.theming.interfaces import IThemingPolicy
+from plone.base.utils import is_truthy
 from plone.registry.interfaces import IRegistry
 from zope.component import queryUtility
 from zope.component.hooks import getSite
@@ -76,7 +77,7 @@ class ThemingPolicy:
         debug_mode = getConfiguration().debug_mode
 
         # Check for diazo.off request parameter
-        if debug_mode and utils.yesno(self.request.get("diazo.off", False)):
+        if debug_mode and is_truthy(self.request.get("diazo.off", False)):
             return False
 
         if not settings:

--- a/src/plone/app/theming/tests/test_utils.py
+++ b/src/plone/app/theming/tests/test_utils.py
@@ -482,33 +482,6 @@ class TestUnit(unittest.TestCase):
         path = os.path.join(os.path.dirname(__file__), "zipfiles", filename)
         return open(path, "rb")
 
-    def test_yesno(self):
-        """Test the `yesno` utility function with different inputs."""
-        from plone.app.theming.utils import yesno
-
-        self.assertTrue(yesno(True))
-        self.assertTrue(yesno(1))
-        self.assertTrue(yesno("1"))
-        self.assertTrue(yesno("TRUE"))
-        self.assertTrue(yesno("tRUE"))
-        self.assertTrue(yesno("true"))
-        self.assertTrue(yesno("y"))
-        self.assertTrue(yesno("Y"))
-        self.assertTrue(yesno("yEs"))
-        self.assertTrue(yesno("yes"))
-        self.assertTrue(yesno("on"))
-
-        self.assertFalse(yesno(None))
-        self.assertFalse(yesno(False))
-        self.assertFalse(yesno(0))
-        self.assertFalse(yesno("0"))
-        self.assertFalse(yesno("FALSE"))
-        self.assertFalse(yesno("fALSE"))
-        self.assertFalse(yesno("false"))
-        self.assertFalse(yesno("n"))
-        self.assertFalse(yesno("NO"))
-        self.assertFalse(yesno("no"))
-
     def test_extractThemeInfo_default_rules(self):
         with self._open_zipfile("default_rules.zip") as fp:
             zf = zipfile.ZipFile(fp)

--- a/src/plone/app/theming/transform.py
+++ b/src/plone/app/theming/transform.py
@@ -4,6 +4,7 @@ from os import environ
 from plone.app.theming import utils
 from plone.app.theming.interfaces import IThemingLayer
 from plone.app.theming.zmi import patch_zmi
+from plone.base.utils import is_truthy
 from plone.transformchain.interfaces import ITransform
 from repoze.xmliter.utils import getHTMLSerializer
 from zope.component import adapter
@@ -40,7 +41,7 @@ class ThemeTransform:
         """
         if not getConfiguration().debug_mode:
             return False
-        return utils.yesno(self.request.get("diazo.debug", False))
+        return is_truthy(self.request.get("diazo.debug", False))
 
     def develop_theme(self):
         """Check if the theme should be recompiled
@@ -50,7 +51,7 @@ class ThemeTransform:
             return False
         if self.debug_theme():
             return True
-        if utils.yesno(environ.get("DIAZO_ALWAYS_CACHE_RULES", False)):
+        if is_truthy(environ.get("DIAZO_ALWAYS_CACHE_RULES", False)):
             return False
         return True
 

--- a/src/plone/app/theming/utils.py
+++ b/src/plone/app/theming/utils.py
@@ -43,11 +43,6 @@ import os
 LOGGER = logging.getLogger("plone.app.theming")
 
 
-def yesno(value) -> bool:
-    """Return `true`, if "yes" was meant, `false` otherwise."""
-    return value and str(value).lower() in ("1", "y", "yes", "t", "true", "on")
-
-
 @implementer(INoRequest)
 class NoRequest:
     """Fallback to enable querying for the policy adapter


### PR DESCRIPTION
…the yesno utility which was introduced some commits before.

@ale-rt I'd create a new branch of plone.app.theming for Plone 6.0 because Plone 6.0 depends on plone.base 1.x and I don't see much worth in backporting the `is_truthy` there.