### PR TITLE
feat: add @themes REST API endpoint

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -12,3 +12,6 @@ extra_lines = """
 
 [tox]
 test_matrix = {"6.2" = ["*"]}
+
+[pyproject]
+dependencies_ignores = "['plone.restapi', 'plone.rest']"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -919,3 +919,110 @@ This is a complete example::
         def __call__(self):
             self.request.response.setHeader('X-Theme-Disabled', '1')
             return super(NoDiazoView).__call__()
+
+
+REST API
+========
+
+When ``plone.restapi`` is installed alongside ``plone.app.theming``, a ``@themes``
+endpoint is available on the Plone site root.
+It requires the ``cmf.ManagePortal`` permission and is particularly useful in
+containerized deployments where access to the Plone control panel is unavailable.
+
+Listing themes
+--------------
+
+Send a ``GET`` request to ``@themes`` to retrieve all available themes::
+
+    GET /Plone/@themes HTTP/1.1
+    Accept: application/json
+
+Response::
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    [
+      {
+        "@id": "http://localhost:8080/Plone/@themes/barceloneta",
+        "id": "barceloneta",
+        "title": "Barceloneta Theme",
+        "description": "The default Plone theme",
+        "active": true,
+        "preview": "/++theme++barceloneta/preview.png",
+        "rules": "/++theme++barceloneta/rules.xml"
+      }
+    ]
+
+Each theme object contains:
+
+- ``@id``: hypermedia link to the theme resource
+- ``id``: the theme identifier
+- ``title``: the friendly name of the theme
+- ``description``: description of the theme
+- ``active``: whether this theme is currently active
+- ``preview``: path to the theme preview image (or ``null``)
+- ``rules``: path to the theme rules file
+
+Reading a single theme
+----------------------
+
+Append the theme ID to the endpoint path::
+
+    GET /Plone/@themes/barceloneta HTTP/1.1
+    Accept: application/json
+
+Returns the same object structure as one entry in the list above.
+Returns ``404`` if the theme ID is not found.
+
+Uploading a theme
+-----------------
+
+Send a ``POST`` request with a ZIP archive as ``multipart/form-data``::
+
+    POST /Plone/@themes HTTP/1.1
+    Content-Type: multipart/form-data
+
+    themeArchive=<zip file>
+    enable=true        (optional: activate the theme after upload)
+    replace=true       (optional: overwrite an existing theme with the same ID)
+
+Response on success::
+
+    HTTP/1.1 201 Created
+    Content-Type: application/json
+
+    {
+      "@id": "http://localhost:8080/Plone/@themes/mytheme",
+      "id": "mytheme",
+      "title": "My Theme"
+    }
+
+Returns ``400`` for a missing or invalid archive, ``409`` if the theme already
+exists and ``replace`` was not set to ``true``.
+
+Activating a theme
+------------------
+
+Send a ``PATCH`` request with ``{"active": true}``::
+
+    PATCH /Plone/@themes/barceloneta HTTP/1.1
+    Content-Type: application/json
+
+    {"active": true}
+
+Returns ``204 No Content`` on success.
+Returns ``404`` if the theme is not found.
+
+Deactivating a theme
+--------------------
+
+Send a ``PATCH`` request with ``{"active": false}``::
+
+    PATCH /Plone/@themes/barceloneta HTTP/1.1
+    Content-Type: application/json
+
+    {"active": false}
+
+Returns ``204 No Content`` on success.
+This disables Diazo theming entirely (no theme will be applied).

--- a/news/276.feature
+++ b/news/276.feature
@@ -1,0 +1,1 @@
+Added ``@themes`` REST API endpoint to list, upload, and activate themes programmatically. @bsuttor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ Zope = [
 ]
 python-dateutil = ['dateutil']
 pytest-plone = ['pytest', 'zope.pytestlayer', 'plone.testing', 'plone.app.testing']
+ignore-packages = ['plone.restapi', 'plone.rest']
 
 ##
 # Add extra configuration options in .meta.toml:

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
             "plone.app.testing",
             "plone.app.contenttypes[test]",
             "plone.testing",
+            "plone.restapi[test]",
         ],
     },
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "plone.resource",
         "plone.resourceeditor>=2.0.0",
         "plone.staticresources",
+        "plone.protect",
         "plone.subrequest",
         "plone.transformchain",
         "python-dateutil",

--- a/src/plone/app/theming/configure.zcml
+++ b/src/plone/app/theming/configure.zcml
@@ -21,6 +21,11 @@
   <include package=".exportimport" />
   <include package=".plugins" />
 
+  <include
+      package=".restapi"
+      zcml:condition="installed plone.restapi"
+      />
+
   <gs:registerProfile
       name="default"
       title="Diazo theme support"

--- a/src/plone/app/theming/restapi/configure.zcml
+++ b/src/plone/app/theming/restapi/configure.zcml
@@ -1,0 +1,35 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    >
+
+  <include
+      package="plone.rest"
+      file="meta.zcml"
+      />
+
+  <plone:service
+      method="GET"
+      factory=".get.ThemesGet"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      permission="cmf.ManagePortal"
+      name="@themes"
+      />
+
+  <plone:service
+      method="POST"
+      factory=".post.ThemesPost"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      permission="cmf.ManagePortal"
+      name="@themes"
+      />
+
+  <plone:service
+      method="PATCH"
+      factory=".patch.ThemesPatch"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      permission="cmf.ManagePortal"
+      name="@themes"
+      />
+
+</configure>

--- a/src/plone/app/theming/restapi/get.py
+++ b/src/plone/app/theming/restapi/get.py
@@ -1,0 +1,46 @@
+from plone.app.theming.interfaces import IThemeSettings
+from plone.app.theming.utils import getAvailableThemes
+from plone.registry.interfaces import IRegistry
+from plone.restapi.services import Service
+from zope.component import getUtility
+from zope.interface import implementer
+from zope.publisher.interfaces import IPublishTraverse
+
+
+@implementer(IPublishTraverse)
+class ThemesGet(Service):
+    def __init__(self, context, request):
+        super().__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        self.params.append(name)
+        return self
+
+    def reply(self):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(IThemeSettings, False)
+        current = settings.currentTheme
+
+        themes = getAvailableThemes()
+
+        if self.params:
+            name = self.params[0]
+            for theme in themes:
+                if theme.__name__ == name:
+                    return self._serialize(theme, current)
+            self.request.response.setStatus(404)
+            return {"error": "Theme not found"}
+
+        return [self._serialize(t, current) for t in themes]
+
+    def _serialize(self, theme, current_name):
+        return {
+            "@id": f"{self.context.absolute_url()}/@themes/{theme.__name__}",
+            "id": theme.__name__,
+            "title": theme.title,
+            "description": theme.description,
+            "active": theme.__name__ == current_name,
+            "preview": theme.preview,
+            "rules": theme.rules,
+        }

--- a/src/plone/app/theming/restapi/patch.py
+++ b/src/plone/app/theming/restapi/patch.py
@@ -1,0 +1,52 @@
+from plone.app.theming.interfaces import IThemeSettings
+from plone.app.theming.utils import applyTheme
+from plone.app.theming.utils import getAvailableThemes
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.registry.interfaces import IRegistry
+from plone.restapi.deserializer import json_body
+from plone.restapi.services import Service
+from zope.component import getUtility
+from zope.interface import alsoProvides
+from zope.interface import implementer
+from zope.publisher.interfaces import IPublishTraverse
+
+
+@implementer(IPublishTraverse)
+class ThemesPatch(Service):
+    def __init__(self, context, request):
+        super().__init__(context, request)
+        self.params = []
+
+    def publishTraverse(self, request, name):
+        self.params.append(name)
+        return self
+
+    def reply(self):
+        alsoProvides(self.request, IDisableCSRFProtection)
+        if not self.params:
+            self.request.response.setStatus(400)
+            return {"error": "Theme name required in URL"}
+
+        theme_name = self.params[0]
+        body = json_body(self.request)
+        active = body.get("active")
+
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(IThemeSettings, False)
+
+        if active is True:
+            themes = getAvailableThemes()
+            theme = next((t for t in themes if t.__name__ == theme_name), None)
+            if theme is None:
+                self.request.response.setStatus(404)
+                return {"error": "Theme not found"}
+            applyTheme(theme)
+            settings.enabled = True
+        elif active is False:
+            applyTheme(None)
+            settings.enabled = False
+        else:
+            self.request.response.setStatus(400)
+            return {"error": "Body must contain 'active': true or false"}
+
+        return self.reply_no_content()

--- a/src/plone/app/theming/restapi/post.py
+++ b/src/plone/app/theming/restapi/post.py
@@ -1,0 +1,68 @@
+from plone.app.theming.interfaces import IThemeSettings
+from plone.app.theming.plugins.utils import getPlugins
+from plone.app.theming.utils import applyTheme
+from plone.app.theming.utils import extractThemeInfo
+from plone.app.theming.utils import getOrCreatePersistentResourceDirectory
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.registry.interfaces import IRegistry
+from plone.restapi.services import Service
+from zope.component import getUtility
+from zope.interface import alsoProvides
+
+import zipfile
+
+
+class ThemesPost(Service):
+    def reply(self):
+        alsoProvides(self.request, IDisableCSRFProtection)
+
+        theme_archive = self.request.form.get("themeArchive")
+        if not theme_archive:
+            self.request.response.setStatus(400)
+            return {"error": "Missing 'themeArchive' field"}
+
+        enable = self.request.form.get("enable", "false").lower() == "true"
+        replace = self.request.form.get("replace", "false").lower() == "true"
+
+        try:
+            theme_zip = zipfile.ZipFile(theme_archive)
+        except (zipfile.BadZipFile, zipfile.LargeZipFile) as e:
+            self.request.response.setStatus(400)
+            return {"error": f"Invalid zip file: {e}"}
+
+        try:
+            theme_info = extractThemeInfo(theme_zip, checkRules=False)
+        except (ValueError, KeyError) as e:
+            self.request.response.setStatus(400)
+            return {"error": f"Invalid theme: {e}"}
+
+        theme_container = getOrCreatePersistentResourceDirectory()
+        theme_name = theme_info.__name__
+
+        if theme_name in theme_container:
+            if not replace:
+                self.request.response.setStatus(409)
+                return {
+                    "error": f"Theme '{theme_name}' already exists. Use replace=true to overwrite."
+                }
+            del theme_container[theme_name]
+
+        theme_container.importZip(theme_zip)
+
+        # Call plugin lifecycle hooks
+        theme_directory = theme_container[theme_name]
+        for _name, plugin in getPlugins():
+            plugin.onCreated(theme_name, {}, theme_directory)
+
+        if enable:
+            applyTheme(theme_info)
+            registry = getUtility(IRegistry)
+            settings = registry.forInterface(IThemeSettings, False)
+            settings.enabled = True
+
+        self.request.response.setStatus(201)
+        return {
+            "@id": f"{self.context.absolute_url()}/@themes/{theme_name}",
+            "id": theme_name,
+            "title": theme_info.title,
+        }

--- a/src/plone/app/theming/testing.py
+++ b/src/plone/app/theming/testing.py
@@ -5,6 +5,14 @@ from plone.app.testing.layers import FunctionalTesting
 from plone.app.testing.layers import IntegrationTesting
 from zope.configuration import xmlconfig
 
+try:
+    from plone.restapi.testing import PLONE_RESTAPI_DX_FIXTURE
+    from plone.testing import zope
+
+    HAS_RESTAPI = True
+except ImportError:
+    HAS_RESTAPI = False
+
 
 class Theming(PloneSandboxLayer):
     defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
@@ -34,3 +42,29 @@ THEMING_INTEGRATION_TESTING = IntegrationTesting(
 THEMING_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(THEMING_FIXTURE,), name="Theming:Functional"
 )
+
+
+if HAS_RESTAPI:
+
+    class ThemingRestAPI(PloneSandboxLayer):
+        defaultBases = (PLONE_RESTAPI_DX_FIXTURE,)
+
+        def setUpZope(self, app, configurationContext):
+            import plone.app.theming
+
+            xmlconfig.file(
+                "configure.zcml", plone.app.theming, context=configurationContext
+            )
+
+            from plone.app.theming.plugins.hooks import onStartup
+
+            onStartup(None)
+
+        def setUpPloneSite(self, portal):
+            applyProfile(portal, "plone.app.theming:default")
+
+    THEMING_RESTAPI_FIXTURE = ThemingRestAPI()
+    THEMING_RESTAPI_FUNCTIONAL_TESTING = FunctionalTesting(
+        bases=(THEMING_RESTAPI_FIXTURE, zope.WSGI_SERVER_FIXTURE),
+        name="Theming:RESTAPIFunctional",
+    )

--- a/src/plone/app/theming/tests/test_restapi_themes.py
+++ b/src/plone/app/theming/tests/test_restapi_themes.py
@@ -1,0 +1,199 @@
+from plone.app.testing import setRoles
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_ID
+from plone.app.theming.testing import THEMING_RESTAPI_FUNCTIONAL_TESTING
+from plone.restapi.testing import RelativeSession
+
+import io
+import os
+import unittest
+
+
+def get_theming_zipfile(name):
+    """Return the path to a plone.app.theming test zip file."""
+    import plone.app.theming.tests
+
+    tests_dir = os.path.dirname(plone.app.theming.tests.__file__)
+    return os.path.join(tests_dir, "zipfiles", name)
+
+
+class TestServicesThemes(unittest.TestCase):
+    layer = THEMING_RESTAPI_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.app = self.layer["app"]
+        self.portal = self.layer["portal"]
+        self.portal_url = self.portal.absolute_url()
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        self.api_session = RelativeSession(self.portal_url, test=self)
+        self.api_session.headers.update({"Accept": "application/json"})
+        self.api_session.auth = (SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
+
+    def tearDown(self):
+        self.api_session.close()
+
+    def test_get_themes_list(self):
+        response = self.api_session.get("/@themes")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIsInstance(data, list)
+        self.assertGreater(len(data), 0)
+        # Each theme should have basic fields
+        theme = data[0]
+        self.assertIn("id", theme)
+        self.assertIn("title", theme)
+        self.assertIn("active", theme)
+        self.assertIn("@id", theme)
+
+    def test_get_theme_by_name(self):
+        # First get list to find a valid theme name
+        response = self.api_session.get("/@themes")
+        themes = response.json()
+        theme_id = themes[0]["id"]
+
+        response = self.api_session.get(f"/@themes/{theme_id}")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["id"], theme_id)
+
+    def test_get_theme_not_found(self):
+        response = self.api_session.get("/@themes/nonexistent-theme-xyz")
+        self.assertEqual(response.status_code, 404)
+
+    def test_post_theme_upload(self):
+        zip_path = get_theming_zipfile("manifest_rules.zip")
+        if not os.path.exists(zip_path):
+            self.skipTest("plone.app.theming test zips not available")
+
+        with open(zip_path, "rb") as f:
+            response = self.api_session.post(
+                "/@themes",
+                files={"themeArchive": ("manifest_rules.zip", f, "application/zip")},
+            )
+
+        self.assertEqual(response.status_code, 201)
+        data = response.json()
+        self.assertIn("id", data)
+        self.assertIn("title", data)
+        self.assertIn("@id", data)
+
+    def test_post_theme_missing_archive(self):
+        response = self.api_session.post(
+            "/@themes",
+            data={},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+
+    def test_post_theme_invalid_zip(self):
+        fake_zip = io.BytesIO(b"not a zip file")
+        response = self.api_session.post(
+            "/@themes",
+            files={"themeArchive": ("bad.zip", fake_zip, "application/zip")},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.json())
+
+    def test_post_theme_duplicate_without_replace(self):
+        zip_path = get_theming_zipfile("manifest_rules.zip")
+        if not os.path.exists(zip_path):
+            self.skipTest("plone.app.theming test zips not available")
+
+        # Upload once
+        with open(zip_path, "rb") as f:
+            self.api_session.post(
+                "/@themes",
+                files={"themeArchive": ("manifest_rules.zip", f, "application/zip")},
+            )
+
+        # Upload again without replace
+        with open(zip_path, "rb") as f:
+            response = self.api_session.post(
+                "/@themes",
+                files={"themeArchive": ("manifest_rules.zip", f, "application/zip")},
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn("error", response.json())
+
+    def test_post_theme_duplicate_with_replace(self):
+        zip_path = get_theming_zipfile("manifest_rules.zip")
+        if not os.path.exists(zip_path):
+            self.skipTest("plone.app.theming test zips not available")
+
+        # Upload once
+        with open(zip_path, "rb") as f:
+            self.api_session.post(
+                "/@themes",
+                files={"themeArchive": ("manifest_rules.zip", f, "application/zip")},
+            )
+
+        # Upload again with replace=true
+        with open(zip_path, "rb") as f:
+            response = self.api_session.post(
+                "/@themes",
+                files={
+                    "themeArchive": ("manifest_rules.zip", f, "application/zip"),
+                },
+                data={"replace": "true"},
+            )
+
+        self.assertEqual(response.status_code, 201)
+
+    def test_patch_theme_activate(self):
+        # Get a theme name from the list
+        response = self.api_session.get("/@themes")
+        themes = response.json()
+        theme_id = themes[0]["id"]
+
+        response = self.api_session.patch(
+            f"/@themes/{theme_id}",
+            json={"active": True},
+        )
+        self.assertEqual(response.status_code, 204)
+
+    def test_patch_theme_deactivate(self):
+        # Get a theme name from the list
+        response = self.api_session.get("/@themes")
+        themes = response.json()
+        theme_id = themes[0]["id"]
+
+        # Activate first
+        self.api_session.patch(
+            f"/@themes/{theme_id}",
+            json={"active": True},
+        )
+
+        # Then deactivate
+        response = self.api_session.patch(
+            f"/@themes/{theme_id}",
+            json={"active": False},
+        )
+        self.assertEqual(response.status_code, 204)
+
+    def test_patch_theme_not_found(self):
+        response = self.api_session.patch(
+            "/@themes/nonexistent-theme-xyz",
+            json={"active": True},
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_patch_theme_no_name(self):
+        response = self.api_session.patch(
+            "/@themes",
+            json={"active": True},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_patch_theme_invalid_body(self):
+        response = self.api_session.get("/@themes")
+        themes = response.json()
+        theme_id = themes[0]["id"]
+
+        response = self.api_session.patch(
+            f"/@themes/{theme_id}",
+            json={"active": "maybe"},
+        )
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
Ports GET/POST/PATCH @themes endpoint from plone.restapi, conditionally loaded when plone.restapi is installed. Includes functional tests and documentation.

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #276 

